### PR TITLE
Build issues

### DIFF
--- a/collections/caravan.go
+++ b/collections/caravan.go
@@ -55,6 +55,10 @@ type Keyer interface {
 	Key() Key
 }
 
+func (k Key) String() string {
+	return string(k)
+}
+
 // CreateCaravan returns an initialized caravan struct
 func CreateCaravan() *Caravan {
 	return &Caravan{

--- a/importer.go
+++ b/importer.go
@@ -15,7 +15,7 @@ type Importer struct {
 // Import is the implementation of types.Importer
 func (i *Importer) Import(path string) (*types.Package, error) {
 	// fmt.Printf("Importer looking for '%s'\n", path)
-	p, err := i.locatePackages(path)
+	p, err := i.locatePackages(collections.Key(path))
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +28,7 @@ func (i *Importer) Import(path string) (*types.Package, error) {
 
 // ImportFrom is the implementation of types.ImporterFrom
 func (i *Importer) ImportFrom(path, srcDir string, mode types.ImportMode) (*types.Package, error) {
-	absPath, err := i.l.findImportPath(path, srcDir)
+	absPath, err := i.l.findImportPath(path, collections.Key(srcDir))
 	if err != nil {
 		fmt.Printf("Failed to locate import path for %s, %s:\n\t%s", path, srcDir, err.Error())
 		return nil, fmt.Errorf("Failed to locate import path for %s, %s:\n\t%s", path, srcDir, err.Error())
@@ -48,9 +48,9 @@ func (i *Importer) ImportFrom(path, srcDir string, mode types.ImportMode) (*type
 	return p.typesPkg, nil
 }
 
-func (i *Importer) locatePackages(path string) (*Package, error) {
+func (i *Importer) locatePackages(path collections.Key) (*Package, error) {
 	i.l.caravanMutex.Lock()
-	n, ok := i.l.caravan.Find(collections.Key(path))
+	n, ok := i.l.caravan.Find(path)
 	i.l.caravanMutex.Unlock()
 	if !ok {
 		fmt.Printf("**** Not found! *****\n")

--- a/loader.go
+++ b/loader.go
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -99,7 +98,6 @@ type Package struct {
 
 // Key returns the collections.Key for the given Package
 func (p *Package) Key() collections.Key {
-	// return collections.Key(p.absPath)
 	return p.absPath
 }
 
@@ -167,11 +165,6 @@ func NewLoader(options ...LoaderOption) *Loader {
 	c := &types.Config{
 		Error: func(e error) {
 			if terror, ok := e.(types.Error); ok {
-				// Let's try to get the stack first.
-
-				stack := debug.Stack()
-				fmt.Printf("ERROR: (stack)\n\t%s\n", string(stack))
-
 				position := terror.Fset.Position(terror.Pos)
 				absPath := filepath.Dir(position.Filename)
 				l.caravanMutex.Lock()
@@ -307,7 +300,7 @@ func (l *Loader) processStateChange(absPath collections.Key) {
 
 	switch loadState {
 	case queued:
-		// fmt.Printf("PSC: %s: current state: %d\n", l.shortName(absPath), loadState)
+		fmt.Printf("PSC: %s: current state: %d\n", l.shortName(absPath), loadState)
 
 		l.processDirectory(p)
 
@@ -315,7 +308,7 @@ func (l *Loader) processStateChange(absPath collections.Key) {
 		p.c.Broadcast()
 		l.stateChange <- absPath
 	case unloaded:
-		// fmt.Printf("PSC: %s: current state: %d\n", l.shortName(absPath), loadState)
+		fmt.Printf("PSC: %s: current state: %d\n", l.shortName(absPath), loadState)
 
 		haveGo := l.processGoFiles(p)
 		haveCgo := l.processCgoFiles(p)
@@ -329,7 +322,7 @@ func (l *Loader) processStateChange(absPath collections.Key) {
 		p.c.Broadcast()
 		l.stateChange <- absPath
 	case loadedGo:
-		// fmt.Printf("PSC: %s: current state: %d\n", l.shortName(absPath), loadState)
+		fmt.Printf("PSC: %s: current state: %d\n", l.shortName(absPath), loadState)
 
 		haveTestGo := l.processTestGoFiles(p)
 		if haveTestGo && p.buildPkg != nil {
@@ -409,7 +402,6 @@ func (l *Loader) processComplete(p *Package) {
 	files := make([]*ast.File, len(p.files))
 	i := 0
 	for _, v := range p.files {
-		// fmt.Printf("\t%s\n", l.fset.Position(v.file.Pos()).Filename)
 		f := v
 		files[i] = f.file
 		i++
@@ -481,8 +473,6 @@ func (l *Loader) processGoFiles(p *Package) bool {
 		if err != nil {
 			fmt.Printf(" GF: ERROR: While parsing %s:\n\t%s\n", fpath, err.Error())
 		}
-
-		// fmt.Printf(" GF: %s: Processing AST %s\n", l.shortName(p.absPath), fpath)
 
 		l.processAstFile(p, fname, astf, p.importPaths)
 	}
@@ -690,7 +680,6 @@ func (l *Loader) processTestGoFiles(p *Package) bool {
 	fnames := p.buildPkg.TestGoFiles
 	if len(fnames) == 0 {
 		// No test files; continue on.
-		// fmt.Printf("TFG: %s: no test Go files\n", l.shortName(d.absPath))
 		return false
 	}
 

--- a/workspace.go
+++ b/workspace.go
@@ -45,7 +45,7 @@ func (w *Workspace) AssignAST() {
 	w.Loader.caravan.Iter(func(_ collections.Key, node *collections.Node) bool {
 		pkg := node.Element.(*Package)
 		for fname, file := range pkg.files {
-			fpath := filepath.Join(pkg.absPath, fname)
+			fpath := filepath.Join(pkg.absPath.String(), fname)
 			w.Files[fpath] = file.file
 		}
 		return true


### PR DESCRIPTION
Loading a large project (such as Hugo) with Go, Cgo, and Go Test (not External Go Test) files can cause issues with the type checker.  The type checker will emit errors such as:

```
/usr/local/Cellar/go/1.9.2/libexec/src/net/lookup_test.go:73 cannot use t (variable of type */usr/local/Cellar/go/1.9.2/libexec/src/testing.T) as */usr/local/Cellar/go/1.9.2/libexec/src/testing.T value in argument to testenv.SkipFlakyNet
```

It appears that the type checker is getting confused about type comparisons.  This only happens when including the Test pass; there are no errors otherwise.

Digging into a stack trace, it appears that the problem comes from a comparison of type instances.  The error message makes it appear as though they are comparing apples to apples, however, they are actually different instances.  When the code type checks on the second pass with Test included, the type package that the checker emits is replaced, and all the original instances are gone.

The solution to this problem is to only keep the first type package.  This way, all the type instances are consistent.

This may cause issues later.  A second solution may be to do the Go, Cgo, and Test all in one pass.