### PR TITLE
Remove collections.Key

### DIFF
--- a/collections/caravan_test.go
+++ b/collections/caravan_test.go
@@ -5,11 +5,11 @@ import (
 )
 
 type Foo struct {
-	key     Key
+	key     string
 	checked bool
 }
 
-func (f *Foo) Key() Key {
+func (f *Foo) Key() string {
 	return f.key
 }
 
@@ -292,7 +292,7 @@ func Test_Caravan_Walk_Flatten(t *testing.T) {
 					}
 
 					i := 0
-					visited := map[Key]bool{}
+					visited := map[string]bool{}
 					c.Walk(tc.dir, func(n *Node) {
 						// Use this to test the fan-in, fan out, etc.
 						key := n.Element.Key()
@@ -313,8 +313,8 @@ func Test_Caravan_Walk_Flatten(t *testing.T) {
 }
 
 type order struct {
-	first  Key
-	second Key
+	first  string
+	second string
 }
 
 func Test_Caravan_Walk_Cross(t *testing.T) {
@@ -380,7 +380,7 @@ func Test_Caravan_Walk_Diamond(t *testing.T) {
 	tests := []struct {
 		name   string
 		dir    WalkDirection
-		first  Key
+		first  string
 		orders []order
 	}{
 		{
@@ -445,7 +445,7 @@ func Test_Caravan_Walk_Offsided(t *testing.T) {
 	tests := []struct {
 		name   string
 		dir    WalkDirection
-		first  Key
+		first  string
 		orders []order
 	}{
 		{
@@ -578,7 +578,7 @@ func Test_Caravan_Walk_Foo(t *testing.T) {
 	tests := []struct {
 		name   string
 		dir    WalkDirection
-		first  Key
+		first  string
 		orders []order
 	}{
 		{
@@ -853,7 +853,7 @@ func createOffsided(t *testing.T) (*Caravan, []*Foo) {
 	return c, []*Foo{f0, f1, f2, f3a, f3b, f4, f5, f6}
 }
 
-func indexOf(walked []Keyer, key Key) int {
+func indexOf(walked []Keyer, key string) int {
 	for k, v := range walked {
 		if v.Key() == key {
 			return k

--- a/importer.go
+++ b/importer.go
@@ -3,8 +3,6 @@ package langd
 import (
 	"fmt"
 	"go/types"
-
-	"github.com/object88/langd/collections"
 )
 
 // Importer implements types.Importer for use in Loader
@@ -15,7 +13,7 @@ type Importer struct {
 // Import is the implementation of types.Importer
 func (i *Importer) Import(path string) (*types.Package, error) {
 	// fmt.Printf("Importer looking for '%s'\n", path)
-	p, err := i.locatePackages(collections.Key(path))
+	p, err := i.locatePackages(path)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +26,7 @@ func (i *Importer) Import(path string) (*types.Package, error) {
 
 // ImportFrom is the implementation of types.ImporterFrom
 func (i *Importer) ImportFrom(path, srcDir string, mode types.ImportMode) (*types.Package, error) {
-	absPath, err := i.l.findImportPath(path, collections.Key(srcDir))
+	absPath, err := i.l.findImportPath(path, srcDir)
 	if err != nil {
 		fmt.Printf("Failed to locate import path for %s, %s:\n\t%s", path, srcDir, err.Error())
 		return nil, fmt.Errorf("Failed to locate import path for %s, %s:\n\t%s", path, srcDir, err.Error())
@@ -48,7 +46,7 @@ func (i *Importer) ImportFrom(path, srcDir string, mode types.ImportMode) (*type
 	return p.typesPkg, nil
 }
 
-func (i *Importer) locatePackages(path collections.Key) (*Package, error) {
+func (i *Importer) locatePackages(path string) (*Package, error) {
 	i.l.caravanMutex.Lock()
 	n, ok := i.l.caravan.Find(path)
 	i.l.caravanMutex.Unlock()

--- a/workspace.go
+++ b/workspace.go
@@ -42,10 +42,10 @@ func (w *Workspace) AssignAST() {
 	w.Fset = w.Loader.fset
 	w.Info = w.Loader.info
 	w.Files = map[string]*ast.File{}
-	w.Loader.caravan.Iter(func(_ collections.Key, node *collections.Node) bool {
+	w.Loader.caravan.Iter(func(_ string, node *collections.Node) bool {
 		pkg := node.Element.(*Package)
 		for fname, file := range pkg.files {
-			fpath := filepath.Join(pkg.absPath.String(), fname)
+			fpath := filepath.Join(pkg.absPath, fname)
 			w.Files[fpath] = file.file
 		}
 		return true


### PR DESCRIPTION
`collections.Key` is an unnecessary abstraction on top of `string` at this point.  Just use string.