### PR TITLE
Start tracking edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Because replies may be generated out of order with asynchronous processing, they
 
 When the IDE opens a file for the user, a `textDocument/didOpen` request is sent to the server.  The server creates a `rope` representation of the file contents, which is altered with `textDocument/didChange` requests.
 
+#### TBD
+
 * Mark the package as altered
 * Debounce edits coming in -- rapid typing should prevent the engine from recompiling too quickly.
 * Go through caravan and re-check packages that are altered, and the packages that consume those altered packages.

--- a/importer.go
+++ b/importer.go
@@ -26,6 +26,7 @@ func (i *Importer) Import(path string) (*types.Package, error) {
 
 // ImportFrom is the implementation of types.ImporterFrom
 func (i *Importer) ImportFrom(path, srcDir string, mode types.ImportMode) (*types.Package, error) {
+	// fmt.Printf("Got ImportFrom:\n\t%s\n\t%s\n", path, srcDir)
 	absPath, err := i.l.findImportPath(path, srcDir)
 	if err != nil {
 		fmt.Printf("Failed to locate import path for %s, %s:\n\t%s", path, srcDir, err.Error())
@@ -42,6 +43,13 @@ func (i *Importer) ImportFrom(path, srcDir string, mode types.ImportMode) (*type
 		fmt.Printf("\t%s (nil)\n", absPath)
 		return nil, fmt.Errorf("Got nil in packages map")
 	}
+
+	// srcP, err := i.locatePackages(srcDir)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// (*srcP.importedLocks)[absPath] = true
+	// p.checkerRWMu.RLock()
 
 	return p.typesPkg, nil
 }

--- a/importer.go
+++ b/importer.go
@@ -26,7 +26,6 @@ func (i *Importer) Import(path string) (*types.Package, error) {
 
 // ImportFrom is the implementation of types.ImporterFrom
 func (i *Importer) ImportFrom(path, srcDir string, mode types.ImportMode) (*types.Package, error) {
-	// fmt.Printf("Got ImportFrom:\n\t%s\n\t%s\n", path, srcDir)
 	absPath, err := i.l.findImportPath(path, srcDir)
 	if err != nil {
 		fmt.Printf("Failed to locate import path for %s, %s:\n\t%s", path, srcDir, err.Error())
@@ -43,13 +42,6 @@ func (i *Importer) ImportFrom(path, srcDir string, mode types.ImportMode) (*type
 		fmt.Printf("\t%s (nil)\n", absPath)
 		return nil, fmt.Errorf("Got nil in packages map")
 	}
-
-	// srcP, err := i.locatePackages(srcDir)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// (*srcP.importedLocks)[absPath] = true
-	// p.checkerRWMu.RLock()
 
 	return p.typesPkg, nil
 }

--- a/loader.go
+++ b/loader.go
@@ -21,6 +21,8 @@ import (
 	"sync/atomic"
 	"unicode/utf8"
 
+	"github.com/object88/rope"
+
 	"github.com/gobwas/glob"
 	"github.com/object88/langd/collections"
 	"github.com/object88/langd/log"
@@ -61,7 +63,8 @@ type Loader struct {
 	conf      *types.Config
 	context   *build.Context
 	Fset      *token.FileSet
-	info      *types.Info
+
+	openedFiles map[string]*rope.Rope
 
 	unsafePath    string
 	filteredPaths []glob.Glob
@@ -89,9 +92,10 @@ type Package struct {
 	absPath   string
 	shortPath string
 
-	buildPkg *build.Package
-	checker  *types.Checker
-	typesPkg *types.Package
+	buildPkg    *build.Package
+	checker     *types.Checker
+	checkerRWMu sync.RWMutex
+	typesPkg    *types.Package
 
 	files           map[string]*File
 	importPaths     map[string]bool
@@ -106,6 +110,11 @@ type Package struct {
 // Key returns the collection key for the given Package
 func (p *Package) Key() string {
 	return p.absPath
+}
+
+// ResetChecker sets the checker to nil
+func (p *Package) ResetChecker() {
+	p.checker = nil
 }
 
 func (p *Package) String() string {
@@ -148,15 +157,8 @@ func NewLoader(options ...LoaderOption) *Loader {
 		done:          false,
 		filteredPaths: globs,
 		Fset:          token.NewFileSet(),
-		info: &types.Info{
-			Defs:       map[*ast.Ident]types.Object{},
-			Implicits:  map[ast.Node]types.Object{},
-			Scopes:     map[ast.Node]*types.Scope{},
-			Selections: map[*ast.SelectorExpr]*types.Selection{},
-			Types:      map[ast.Expr]types.TypeAndValue{},
-			Uses:       map[*ast.Ident]types.Object{},
-		},
-		stateChange: make(chan string),
+		openedFiles:   map[string]*rope.Rope{},
+		stateChange:   make(chan string),
 	}
 
 	for _, opt := range options {
@@ -425,8 +427,17 @@ func (l *Loader) processComplete(p *Package) {
 	}
 
 	if p.checker == nil {
+		info := &types.Info{
+			Defs:       map[*ast.Ident]types.Object{},
+			Implicits:  map[ast.Node]types.Object{},
+			Scopes:     map[ast.Node]*types.Scope{},
+			Selections: map[*ast.SelectorExpr]*types.Selection{},
+			Types:      map[ast.Expr]types.TypeAndValue{},
+			Uses:       map[*ast.Ident]types.Object{},
+		}
+
 		p.typesPkg = types.NewPackage(p.absPath, p.buildPkg.Name)
-		p.checker = types.NewChecker(l.conf, l.Fset, p.typesPkg, l.info)
+		p.checker = types.NewChecker(l.conf, l.Fset, p.typesPkg, info)
 	}
 
 	// Clear previous errors; all will be rechecked.
@@ -443,7 +454,27 @@ func (l *Loader) processComplete(p *Package) {
 	}
 
 	l.checkerMu.Lock()
+	// imports := make([]*Package, len(p.importPaths))
+	// i = 0
+	// for k := range p.importPaths {
+	// 	imports[i] = l.ensurePackage(k)
+	// 	i++
+	// }
+
+	// for _, impPkg := range imports {
+	// 	impPkg.checkerRWMu.RLock()
+	// }
+
+	// p.checkerRWMu.Lock()
+
 	err := p.checker.Files(astFiles)
+
+	// p.checkerRWMu.Unlock()
+
+	// for _, impPkg := range imports {
+	// 	impPkg.checkerRWMu.RUnlock()
+	// }
+
 	l.checkerMu.Unlock()
 
 	if err != nil {
@@ -489,15 +520,23 @@ func (l *Loader) processGoFiles(p *Package) bool {
 	for _, fname := range fnames {
 		fpath := filepath.Join(p.absPath, fname)
 
-		r, err := l.context.OpenFile(fpath)
-		if err != nil {
-			l.Log.Debugf(" GF: ERROR: Failed to read file %s:\n\t%s\n", fpath, err.Error())
-			continue
+		var r io.Reader
+		if of, ok := l.openedFiles[fpath]; ok {
+			r = of.NewReader()
+		} else {
+			var err error
+			r, err = l.context.OpenFile(fpath)
+			if err != nil {
+				l.Log.Debugf(" GF: ERROR: Failed to read file %s:\n\t%s\n", fpath, err.Error())
+				continue
+			}
 		}
 
 		astf, err := parser.ParseFile(l.Fset, fpath, r, parser.AllErrors)
 
-		r.Close()
+		if c, ok := r.(io.Closer); ok {
+			c.Close()
+		}
 
 		if err != nil {
 			l.Log.Debugf(" GF: ERROR: While parsing %s:\n\t%s\n", fpath, err.Error())

--- a/loader.go
+++ b/loader.go
@@ -21,11 +21,10 @@ import (
 	"sync/atomic"
 	"unicode/utf8"
 
-	"github.com/object88/rope"
-
 	"github.com/gobwas/glob"
 	"github.com/object88/langd/collections"
 	"github.com/object88/langd/log"
+	"github.com/object88/rope"
 )
 
 type loadState int32
@@ -62,7 +61,6 @@ type Loader struct {
 	checkerMu sync.Mutex
 	conf      *types.Config
 	context   *build.Context
-	// Fset      *token.FileSet
 
 	openedFiles map[string]*rope.Rope
 
@@ -92,11 +90,10 @@ type Package struct {
 	absPath   string
 	shortPath string
 
-	buildPkg    *build.Package
-	checker     *types.Checker
-	checkerRWMu sync.RWMutex
-	Fset        *token.FileSet
-	typesPkg    *types.Package
+	buildPkg *build.Package
+	checker  *types.Checker
+	Fset     *token.FileSet
+	typesPkg *types.Package
 
 	files           map[string]*File
 	importPaths     map[string]bool
@@ -157,9 +154,8 @@ func NewLoader(options ...LoaderOption) *Loader {
 		closer:        make(chan bool),
 		done:          false,
 		filteredPaths: globs,
-		// Fset:          token.NewFileSet(),
-		openedFiles: map[string]*rope.Rope{},
-		stateChange: make(chan string),
+		openedFiles:   map[string]*rope.Rope{},
+		stateChange:   make(chan string),
 	}
 
 	for _, opt := range options {
@@ -455,27 +451,7 @@ func (l *Loader) processComplete(p *Package) {
 	}
 
 	l.checkerMu.Lock()
-	// imports := make([]*Package, len(p.importPaths))
-	// i = 0
-	// for k := range p.importPaths {
-	// 	imports[i] = l.ensurePackage(k)
-	// 	i++
-	// }
-
-	// for _, impPkg := range imports {
-	// 	impPkg.checkerRWMu.RLock()
-	// }
-
-	// p.checkerRWMu.Lock()
-
 	err := p.checker.Files(astFiles)
-
-	// p.checkerRWMu.Unlock()
-
-	// for _, impPkg := range imports {
-	// 	impPkg.checkerRWMu.RUnlock()
-	// }
-
 	l.checkerMu.Unlock()
 
 	if err != nil {

--- a/requests/didSave.go
+++ b/requests/didSave.go
@@ -47,29 +47,13 @@ func (rh *didSaveHandler) preprocess(params *json.RawMessage) error {
 }
 
 func (rh *didSaveHandler) work() error {
-	// Sanity check: is our in-memory document different from the one that
-	// the client is saving?
+	// TODO: is our in-memory document different from the one that
+	// the client is saving?  If not, skip the `ReplaceText` call.
 
 	if rh.text != nil {
 		// Provided new contents for the file; update.
 		rh.h.workspace.ReplaceFile(rh.fpath, *rh.text)
 	}
-
-	// r := rh.h.workspace.Loader.openedFiles[rh.fpath]
-	// if r.ByteLength() != len(rh.text) {
-	// 	// Not the same length, different file.
-	// 	fmt.Printf("in-memory:\n%s\nprovided:\n%s\n", r.String(), rh.text)
-	// 	return fmt.Errorf("%s: In-memory does not match client version; different length: %d/%d", rh.fpath, r.ByteLength(), len(rh.text))
-	// }
-
-	// rtext := r.String()
-	// for i := 0; i < len(rtext); i++ {
-	// 	if rtext[i] != rh.text[i] {
-	// 		// Different byte; different file.
-	// 		fmt.Printf("in-memory:\n%s\nprovided:\n%s\n", rtext, rh.text)
-	// 		return fmt.Errorf("%s: In-memory does not match client version; starting at %d", rh.fpath, i)
-	// 	}
-	// }
 
 	return nil
 }

--- a/requests/initialize.go
+++ b/requests/initialize.go
@@ -80,8 +80,6 @@ func (h *Handler) readRoot(root string) {
 	fmt.Printf("Waiting...\n")
 	<-done
 
-	// h.workspace.AssignAST()
-
 	// Start a routine to process requests
 	h.startProcessingQueue()
 

--- a/requests/initialize.go
+++ b/requests/initialize.go
@@ -80,7 +80,7 @@ func (h *Handler) readRoot(root string) {
 	fmt.Printf("Waiting...\n")
 	<-done
 
-	h.workspace.AssignAST()
+	// h.workspace.AssignAST()
 
 	// Start a routine to process requests
 	h.startProcessingQueue()

--- a/workspace.go
+++ b/workspace.go
@@ -95,15 +95,11 @@ func (w *Workspace) CloseFile(absPath string) error {
 // LocateIdent scans the loaded fset for the identifier at the requested
 // position
 func (w *Workspace) LocateIdent(p *token.Position) (*ast.Ident, error) {
-	if _, ok := w.Loader.openedFiles[p.Filename]; ok {
-		// Force reprocessing the AST before we can continue.
-	}
-
 	absPath := filepath.Dir(p.Filename)
 
 	n, ok := w.Loader.caravan.Find(absPath)
 	if !ok {
-		// This is a problem.
+		return nil, fmt.Errorf("No package loaded for '%s'", p.Filename)
 	}
 	pkg := n.Element.(*Package)
 	fi := pkg.files[filepath.Base(p.Filename)]
@@ -148,7 +144,7 @@ func (w *Workspace) LocateDeclaration(p *token.Position) (*token.Position, error
 
 	n, ok := w.Loader.caravan.Find(absPath)
 	if !ok {
-		// This is a problem.
+		return nil, fmt.Errorf("No package loaded for '%s'", p.Filename)
 	}
 	pkg := n.Element.(*Package)
 	fi := pkg.files[filepath.Base(p.Filename)]

--- a/workspace.go
+++ b/workspace.go
@@ -3,22 +3,19 @@ package langd
 import (
 	"fmt"
 	"go/ast"
-	"go/parser"
 	"go/token"
 	"go/types"
 	"path/filepath"
 	"sync"
 
-	"github.com/object88/langd/collections"
 	"github.com/object88/langd/log"
 	"github.com/object88/rope"
 )
 
 // Workspace is a mass of code
 type Workspace struct {
-	Files       map[string]*ast.File
-	OpenedFiles map[string]*rope.Rope
-	rwm         sync.RWMutex
+	// Files map[string]*ast.File
+	rwm sync.RWMutex
 
 	Loader *Loader
 
@@ -27,33 +24,30 @@ type Workspace struct {
 
 // CreateWorkspace returns a new instance of the Workspace struct
 func CreateWorkspace(loader *Loader, log *log.Log) *Workspace {
-	openedFiles := map[string]*rope.Rope{}
-
 	return &Workspace{
-		OpenedFiles: openedFiles,
-		Loader:      loader,
-		log:         log,
+		Loader: loader,
+		log:    log,
 	}
 }
 
 // AssignAST will inform the workspace of its file set, info, paths, etc.
-func (w *Workspace) AssignAST() {
-	w.Files = map[string]*ast.File{}
-	w.Loader.caravan.Iter(func(_ string, node *collections.Node) bool {
-		pkg := node.Element.(*Package)
-		for fname, file := range pkg.files {
-			fpath := filepath.Join(pkg.absPath, fname)
-			w.Files[fpath] = file.file
-		}
-		return true
-	})
-}
+// func (w *Workspace) AssignAST() {
+// 	w.Files = map[string]*ast.File{}
+// 	w.Loader.caravan.Iter(func(_ string, node *collections.Node) bool {
+// 		pkg := node.Element.(*Package)
+// 		for fname, file := range pkg.files {
+// 			fpath := filepath.Join(pkg.absPath, fname)
+// 			w.Files[fpath] = file.file
+// 		}
+// 		return true
+// 	})
+// }
 
 // ChangeFile applies changes to an opened file
-func (w *Workspace) ChangeFile(absPath string, startLine, startCharacter, endLine, endCharacter int, text string) error {
-	buf, ok := w.OpenedFiles[absPath]
+func (w *Workspace) ChangeFile(absFilepath string, startLine, startCharacter, endLine, endCharacter int, text string) error {
+	buf, ok := w.Loader.openedFiles[absFilepath]
 	if !ok {
-		return fmt.Errorf("File %s is not opened\n", absPath)
+		return fmt.Errorf("File %s is not opened\n", absFilepath)
 	}
 
 	// Have position (line, character), need to transform into offset into file
@@ -74,28 +68,45 @@ func (w *Workspace) ChangeFile(absPath string, startLine, startCharacter, endLin
 
 	fmt.Printf("offsets: [%d:%d]\n", startOffset, endOffset)
 
-	buf.Alter(startOffset, endOffset, text)
+	if err = buf.Alter(startOffset, endOffset, text); err != nil {
+		return err
+	}
+
+	absPath := filepath.Dir(absFilepath)
+	w.Loader.caravanMutex.Lock()
+	n, ok := w.Loader.caravan.Find(absPath)
+	w.Loader.caravanMutex.Unlock()
+
+	if !ok {
+		// Crapola.
+		return fmt.Errorf("Failed to find package for file %s", absFilepath)
+	}
+	p := n.Element.(*Package)
+
+	p.loadState = unloaded
+	w.Loader.done = false
+	w.Loader.stateChange <- absPath
 
 	return nil
 }
 
 // CloseFile will take a file out of the OpenedFiles struct and reparse
 func (w *Workspace) CloseFile(absPath string) error {
-	_, ok := w.OpenedFiles[absPath]
+	_, ok := w.Loader.openedFiles[absPath]
 	if !ok {
 		w.log.Warnf("File %s is not opened\n", absPath)
 		return nil
 	}
 
 	w.log.Debugf("File %s is open...\n", absPath)
-	delete(w.OpenedFiles, absPath)
+	delete(w.Loader.openedFiles, absPath)
 
-	astFile, err := parser.ParseFile(w.Loader.Fset, absPath, nil, 0)
-	if err != nil {
-		w.log.Errorf("Failed to parse file as provided by didOpen: %s\n", err.Error())
-	}
+	// astFile, err := parser.ParseFile(w.Loader.Fset, absPath, nil, 0)
+	// if err != nil {
+	// 	w.log.Errorf("Failed to parse file as provided by didOpen: %s\n", err.Error())
+	// }
 
-	w.Files[absPath] = astFile
+	// w.Files[absPath] = astFile
 
 	w.log.Debugf("File %s is closed\n", absPath)
 
@@ -105,11 +116,21 @@ func (w *Workspace) CloseFile(absPath string) error {
 // LocateIdent scans the loaded fset for the identifier at the requested
 // position
 func (w *Workspace) LocateIdent(p *token.Position) (*ast.Ident, error) {
-	if _, ok := w.OpenedFiles[p.Filename]; ok {
+	if _, ok := w.Loader.openedFiles[p.Filename]; ok {
 		// Force reprocessing the AST before we can continue.
 	}
 
-	f := w.Files[p.Filename]
+	absPath := filepath.Dir(p.Filename)
+
+	n, ok := w.Loader.caravan.Find(absPath)
+	if !ok {
+		// This is a problem.
+	}
+	pkg := n.Element.(*Package)
+	fi := pkg.files[filepath.Base(p.Filename)]
+	f := fi.file
+
+	// f := w.Files[p.Filename]
 	if f == nil {
 		// Failure response is failure.
 		return nil, fmt.Errorf("File %s isn't in our workspace\n", p.Filename)
@@ -145,7 +166,17 @@ func (w *Workspace) LocateIdent(p *token.Position) (*ast.Ident, error) {
 // LocateDeclaration returns the position where the provided identifier is
 // declared & defined
 func (w *Workspace) LocateDeclaration(p *token.Position) (*token.Position, error) {
-	f := w.Files[p.Filename]
+	absPath := filepath.Dir(p.Filename)
+
+	n, ok := w.Loader.caravan.Find(absPath)
+	if !ok {
+		// This is a problem.
+	}
+	pkg := n.Element.(*Package)
+	fi := pkg.files[filepath.Base(p.Filename)]
+	f := fi.file
+
+	// f := w.Files[p.Filename]
 	if f == nil {
 		// Failure response is failure.
 		return nil, fmt.Errorf("File %s isn't in our workspace\n", p.Filename)
@@ -155,10 +186,9 @@ func (w *Workspace) LocateDeclaration(p *token.Position) (*token.Position, error
 
 	fmt.Printf("LocateDeclaration: %s\n", p.Filename)
 
-	e, _ := w.Loader.caravan.Find(filepath.Dir(p.Filename))
-	pkg := e.Element.(*Package)
-
+	i := 0
 	ast.Inspect(f, func(n ast.Node) bool {
+		i++
 		if n == nil {
 			return false
 		}
@@ -172,10 +202,11 @@ func (w *Workspace) LocateDeclaration(p *token.Position) (*token.Position, error
 
 		switch v := n.(type) {
 		case *ast.Ident:
-			fmt.Printf("Found;     %#v\n", n)
+			fmt.Printf("... found ident; %#v\n", v)
 			x = v
 			return false
 		case *ast.SelectorExpr:
+			fmt.Printf("... found selector; %#v\n", v)
 			selPos := v.Sel
 			pSelStart := w.Loader.Fset.Position(selPos.Pos())
 			pSelEnd := w.Loader.Fset.Position(selPos.End())
@@ -197,7 +228,7 @@ func (w *Workspace) LocateDeclaration(p *token.Position) (*token.Position, error
 
 	switch v := x.(type) {
 	case *ast.Ident:
-		fmt.Printf("Have ident\n")
+		fmt.Printf("Have ident %#v\n", v)
 		if v.Obj != nil {
 			fmt.Printf("Ident has obj %#v (%d)\n", v.Obj, v.Pos())
 			identPosition := w.Loader.Fset.Position(v.Obj.Pos())
@@ -208,6 +239,26 @@ func (w *Workspace) LocateDeclaration(p *token.Position) (*token.Position, error
 		// 	identPosition := w.Loader.Fset.Position(xObj.Pos())
 		// 	return &identPosition, nil
 		// }
+		if vDef, ok := pkg.checker.Defs[v]; ok {
+			fmt.Printf("Have vDef from Defs: %#v\n", vDef)
+			identPosition := w.Loader.Fset.Position(vDef.Pos())
+			return &identPosition, nil
+		}
+		if vUse, ok := pkg.checker.Uses[v]; ok {
+			// Used when var is defined in a package, in another file
+			fmt.Printf("Have vUse from Uses: %#v\n", vUse)
+			identPosition := w.Loader.Fset.Position(vUse.Pos())
+			return &identPosition, nil
+
+			// switch v1 := vUse.(type) {
+			// case *types.Var:
+			// 	scope := v1.Parent()
+			// 	scopedObj := scope.Lookup(v.Name)
+			// 	identPosition := w.Loader.Fset.Position(scopedObj.Pos())
+			// 	return &identPosition, nil
+			// }
+		}
+
 	case *ast.SelectorExpr:
 		fmt.Printf("Have SelectorExpr\n")
 
@@ -270,32 +321,54 @@ func (w *Workspace) LocateReferences(x *ast.Ident) *[]token.Position {
 
 // OpenFile shadows the file read from the disk with an in-memory version,
 // which the workspace can accept edits to.
-func (w *Workspace) OpenFile(absPath, text string) error {
-	w.OpenedFiles[absPath] = rope.CreateRope(text)
+func (w *Workspace) OpenFile(absFilepath, text string) error {
+	if _, ok := w.Loader.openedFiles[absFilepath]; ok {
+		return fmt.Errorf("File %s is already opened\n", absFilepath)
+	}
+	w.Loader.openedFiles[absFilepath] = rope.CreateRope(text)
 
 	// DISABLE UNTIL WE ARE ABLE TO RERUN TYPECHECKER
-	// astFile, err := parser.ParseFile(w.Loader.Fset, rh.fpath, rh.text, 0)
+	// astFile, err := parser.ParseFile(w.Loader.Fset, absPath, text, 0)
 	// if err != nil {
-	// 	rh.h.log.Warnf("Failed to parse file as provided by didOpen: %s\n", err.Error())
+	// 	w.Loader.Log.Warnf("Failed to parse file as provided by didOpen: %s\n", err.Error())
 	// }
 
-	// w.Files[rh.fpath] = astFile
+	// w.Files[absPath] = astFile
 
-	w.log.Debugf("Shadowed file '%s'\n", absPath)
+	// n, err := w.Loader.caravan.Find(filepath.Dir(absPath))
+	// p := n.Element.(*Package)
+
+	absPath := filepath.Dir(absFilepath)
+	w.Loader.caravanMutex.Lock()
+	n, ok := w.Loader.caravan.Find(absPath)
+	w.Loader.caravanMutex.Unlock()
+
+	if !ok {
+		// Crapola.
+		return fmt.Errorf("Failed to find package for file %s", absFilepath)
+	}
+	p := n.Element.(*Package)
+
+	p.loadState = unloaded
+	p.ResetChecker()
+	w.Loader.done = false
+	w.Loader.stateChange <- absPath
+
+	w.log.Debugf("Shadowed file '%s'\n", absFilepath)
 
 	return nil
 }
 
 // ReplaceFile replaces the entire contents of an opened file
 func (w *Workspace) ReplaceFile(absPath, text string) error {
-	_, ok := w.OpenedFiles[absPath]
+	_, ok := w.Loader.openedFiles[absPath]
 	if !ok {
 		return fmt.Errorf("File %s is not opened\n", absPath)
 	}
 
 	// Replace the entire document
 	buf := rope.CreateRope(text)
-	w.OpenedFiles[absPath] = buf
+	w.Loader.openedFiles[absPath] = buf
 
 	return nil
 }

--- a/workspace_declaration_import_test.go
+++ b/workspace_declaration_import_test.go
@@ -1,6 +1,7 @@
 package langd
 
 import (
+	"go/token"
 	"testing"
 )
 
@@ -29,9 +30,17 @@ func Test_Workspace_Declaration_Import_Const(t *testing.T) {
 
 	w := workspaceSetup(t, "/go/src/bar", packages, false)
 
-	declOffset := nthIndex2(w, "/go/src/foo/foo.go", src1, "Fooval", 0)
-	usageOffset := nthIndex2(w, "/go/src/bar/bar.go", src2, "Fooval", 0)
-	test(t, w, declOffset, usageOffset)
+	usagePosition := &token.Position{
+		Filename: "/go/src/bar/bar.go",
+		Line:     6,
+		Column:   14,
+	}
+	declPosition := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     3,
+		Column:   3,
+	}
+	test(t, w, usagePosition, declPosition)
 }
 
 func Test_Workspace_Declaration_Import_Func(t *testing.T) {
@@ -59,7 +68,15 @@ func Test_Workspace_Declaration_Import_Func(t *testing.T) {
 
 	w := workspaceSetup(t, "/go/src/bar", packages, false)
 
-	declOffset := nthIndex2(w, "/go/src/foo/foo.go", src1, "FooFunc", 0)
-	usageOffset := nthIndex2(w, "/go/src/bar/bar.go", src2, "FooFunc", 0)
-	test(t, w, declOffset, usageOffset)
+	usagePosition := &token.Position{
+		Filename: "/go/src/bar/bar.go",
+		Line:     6,
+		Column:   14,
+	}
+	declPosition := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     2,
+		Column:   7,
+	}
+	test(t, w, usagePosition, declPosition)
 }

--- a/workspace_declaration_import_test.go
+++ b/workspace_declaration_import_test.go
@@ -40,7 +40,7 @@ func Test_Workspace_Declaration_Import_Const(t *testing.T) {
 		Line:     3,
 		Column:   3,
 	}
-	test(t, w, usagePosition, declPosition)
+	testDeclaration(t, w, usagePosition, declPosition)
 }
 
 func Test_Workspace_Declaration_Import_Func(t *testing.T) {
@@ -78,5 +78,5 @@ func Test_Workspace_Declaration_Import_Func(t *testing.T) {
 		Line:     2,
 		Column:   7,
 	}
-	test(t, w, usagePosition, declPosition)
+	testDeclaration(t, w, usagePosition, declPosition)
 }

--- a/workspace_hugo_test.go
+++ b/workspace_hugo_test.go
@@ -58,8 +58,6 @@ func Test_Workspace_Hugo(t *testing.T) {
 		t.Fatal(buf.String())
 	}
 
-	// w.AssignAST()
-
 	p := &token.Position{
 		Filename: "/Users/bropa18/work/src/github.com/gohugoio/hugo/helpers/processing_stats.go",
 		Line:     109,

--- a/workspace_hugo_test.go
+++ b/workspace_hugo_test.go
@@ -1,0 +1,83 @@
+package langd
+
+import (
+	"bytes"
+	"fmt"
+	"go/token"
+	"testing"
+
+	"github.com/object88/langd/log"
+)
+
+func Test_Workspace_Hugo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	logger := log.Stdout()
+	logger.SetLevel(log.Debug)
+	l := NewLoader()
+	w := CreateWorkspace(l, logger)
+
+	done := l.Start()
+	if done == nil {
+		t.Fatal("Did not check channel back.\n")
+	}
+	fmt.Printf("Have done channel.\n")
+
+	path := "/Users/bropa18/work/src/github.com/gohugoio/hugo"
+
+	fmt.Printf("Going to load %s\n", path)
+
+	err := l.LoadDirectory(path)
+	if err != nil {
+		t.Fatalf("Failed to load directory '%s':\n\t%s\n", path, err.Error())
+	}
+
+	fmt.Printf("Load directory started; blocking...\n")
+
+	<-done
+
+	fmt.Printf("Load directory done\n")
+
+	errCount := 0
+	var buf bytes.Buffer
+	l.Errors(func(file string, errs []FileError) {
+		if len(errs) == 0 {
+			return
+		}
+		buf.WriteString(fmt.Sprintf("Loading error in %s:\n", file))
+		for k, err := range errs {
+			buf.WriteString(fmt.Sprintf("\t%02d: %s:%d %s\n", k, err.Filename, err.Line, err.Message))
+		}
+		errCount += len(errs)
+	})
+
+	if errCount != 0 {
+		buf.WriteString(fmt.Sprintf("Total: %d errors\n", errCount))
+		t.Fatal(buf.String())
+	}
+
+	// w.AssignAST()
+
+	p := &token.Position{
+		Filename: "/Users/bropa18/work/src/github.com/gohugoio/hugo/helpers/processing_stats.go",
+		Line:     109,
+		Column:   24,
+	}
+	declPosition, err := w.LocateDeclaration(p)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if !declPosition.IsValid() {
+		t.Error("Returned declaration position is not valid.")
+	}
+	if declPosition.Filename != "/Users/bropa18/work/src/github.com/gohugoio/hugo/vendor/github.com/olekukonko/tablewriter/table.go" {
+		t.Errorf("Wrong file:\n\t%s\n", declPosition.Filename)
+	}
+	if declPosition.Line != 85 {
+		t.Errorf("Wrong line:\n\t%d\n", declPosition.Line)
+	}
+
+	// t.Errorf("Dump logging...\n\t%s\n", declPosition.String())
+}

--- a/workspace_imports_test.go
+++ b/workspace_imports_test.go
@@ -80,7 +80,7 @@ func setup2(t *testing.T) *Workspace {
 	loader.LoadDirectory("/go/src/foo")
 	<-done
 
-	w.AssignAST()
+	// w.AssignAST()
 
 	errCount := 0
 	w.Loader.Errors(func(file string, errs []FileError) {

--- a/workspace_imports_test.go
+++ b/workspace_imports_test.go
@@ -1,13 +1,5 @@
 package langd
 
-import (
-	"os"
-	"testing"
-
-	"github.com/object88/langd/log"
-	"golang.org/x/tools/go/buildutil"
-)
-
 const identImportsTestProgram1 = `package foo
 
 import (
@@ -57,42 +49,3 @@ func CountCall(source string) {
 // 		t.Fatalf("Returned nil from LocateReferences")
 // 	}
 // }
-
-func setup2(t *testing.T) *Workspace {
-	packages := map[string]map[string]string{
-		"foo": map[string]string{
-			"foo.go": identImportsTestProgram1,
-		},
-		"bar": map[string]string{
-			"bar.go": identImportsTestProgram2,
-		},
-	}
-
-	fc := buildutil.FakeContext(packages)
-	loader := NewLoader(func(l *Loader) {
-		l.context = fc
-	})
-	w := CreateWorkspace(loader, log.CreateLog(os.Stdout))
-	w.log.SetLevel(log.Verbose)
-
-	done := loader.Start()
-	loader.LoadDirectory("/go/src/foo")
-	<-done
-
-	errCount := 0
-	w.Loader.Errors(func(file string, errs []FileError) {
-		if errCount == 0 {
-			t.Errorf("Loading error in %s:\n", file)
-		}
-		for k, err := range errs {
-			t.Errorf("\t%d: %s\n", k, err.Message)
-		}
-		errCount++
-	})
-
-	if errCount != 0 {
-		t.Fatalf("Found %d errors", errCount)
-	}
-
-	return w
-}

--- a/workspace_imports_test.go
+++ b/workspace_imports_test.go
@@ -1,7 +1,6 @@
 package langd
 
 import (
-	"go/token"
 	"os"
 	"testing"
 
@@ -46,18 +45,18 @@ func CountCall(source string) {
 }
 `
 
-func Test_FromImports_LocateReferences_AsFunc(t *testing.T) {
-	w := setup2(t)
+// func Test_FromImports_LocateReferences_AsFunc(t *testing.T) {
+// 	w := setup2(t)
 
-	callCountInvokeOffset := nthIndex(identImportsTestProgram1, "CountCall", 0)
-	callCountInvokePosition := w.Loader.Fset.Position(token.Pos(callCountInvokeOffset + 1))
-	callCountIdent, _ := w.LocateIdent(&callCountInvokePosition)
+// 	callCountInvokeOffset := nthIndex(identImportsTestProgram1, "CountCall", 0)
+// 	callCountInvokePosition := w.Loader.Fset.Position(token.Pos(callCountInvokeOffset + 1))
+// 	callCountIdent, _ := w.LocateIdent(&callCountInvokePosition)
 
-	refPositions := w.LocateReferences(callCountIdent)
-	if nil == refPositions {
-		t.Fatalf("Returned nil from LocateReferences")
-	}
-}
+// 	refPositions := w.LocateReferences(callCountIdent)
+// 	if nil == refPositions {
+// 		t.Fatalf("Returned nil from LocateReferences")
+// 	}
+// }
 
 func setup2(t *testing.T) *Workspace {
 	packages := map[string]map[string]string{
@@ -79,8 +78,6 @@ func setup2(t *testing.T) *Workspace {
 	done := loader.Start()
 	loader.LoadDirectory("/go/src/foo")
 	<-done
-
-	// w.AssignAST()
 
 	errCount := 0
 	w.Loader.Errors(func(file string, errs []FileError) {

--- a/workspace_modify_file_test.go
+++ b/workspace_modify_file_test.go
@@ -107,10 +107,6 @@ func Test_Workspace_Modify_Cross_File(t *testing.T) {
 
 	fmt.Printf("foo2.go:\n%s\n", w.Loader.openedFiles["/go/src/foo/foo2.go"].String())
 
-	// n, _ := w.Loader.caravan.Find("/go/src/foo")
-	// pkg := n.Element.(*Package)
-	// pkg.
-
 	errCount := 0
 	w.Loader.Errors(func(file string, errs []FileError) {
 		for _, err := range errs {

--- a/workspace_modify_file_test.go
+++ b/workspace_modify_file_test.go
@@ -1,0 +1,145 @@
+package langd
+
+import (
+	"fmt"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+func Test_Workspace_Modify_File(t *testing.T) {
+	src1 := `package foo
+	var ival int = 10
+	func foof() int {
+		ival += 1
+		return ival
+	}
+	`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	done := w.Loader.Start()
+
+	if err := w.OpenFile("/go/src/foo/foo.go", src1); err != nil {
+		t.Fatalf("Error while opening file: %s", err.Error())
+	}
+
+	<-done
+
+	declOffset := nthIndex(src1, "ival", 0)
+	usageOffset := nthIndex(src1, "ival", 1)
+	declPosition := w.Loader.Fset.Position(token.Pos(declOffset + 1))
+	usagePosition := w.Loader.Fset.Position(token.Pos(usageOffset + 1))
+	pos, err := w.LocateDeclaration(&usagePosition)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if declPosition.Offset != pos.Offset {
+		t.Fatalf("Incorrect declaration position: expected %d, got %d\n", declPosition.Offset, pos.Offset)
+	}
+
+	if err := w.ChangeFile("/go/src/foo/foo.go", 2, 6, 2, 10, "foos"); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	rope := w.Loader.openedFiles["/go/src/foo/foo.go"]
+	ropeString := rope.String()
+
+	if strings.Contains(ropeString, "foof") {
+		t.Errorf("Changed file still contains foof:\n%s\n", ropeString)
+	}
+	if !strings.Contains(ropeString, "foos") {
+		t.Errorf("Changed file does not contain foos:\n%s\n", ropeString)
+	}
+
+	<-done
+
+	pos, err = w.LocateDeclaration(&usagePosition)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if declPosition.Offset != pos.Offset {
+		t.Fatalf("Incorrect declaration position: expected %d, got %d\n", declPosition.Offset, pos.Offset)
+	}
+
+	// t.Error("Dump")
+}
+
+func Test_Workspace_Modify_Cross_File(t *testing.T) {
+	src1 := `package foo
+	func foof() int {
+		ival += 1
+		return ival
+	}
+	`
+
+	src2 := `package foo
+	var intval int = 100
+	`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo1.go": src1,
+			"foo2.go": src2,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, true)
+
+	done := w.Loader.Start()
+
+	if err := w.OpenFile("/go/src/foo/foo2.go", src2); err != nil {
+		t.Fatalf("Error while opening file: %s", err.Error())
+	}
+
+	<-done
+
+	// Change the definition to reflect what was used in
+	if err := w.ChangeFile("/go/src/foo/foo2.go", 1, 5, 1, 11, "ival"); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	<-done
+
+	fmt.Printf("foo2.go:\n%s\n", w.Loader.openedFiles["/go/src/foo/foo2.go"].String())
+
+	// n, _ := w.Loader.caravan.Find("/go/src/foo")
+	// pkg := n.Element.(*Package)
+	// pkg.
+
+	errCount := 0
+	w.Loader.Errors(func(file string, errs []FileError) {
+		for _, err := range errs {
+			t.Error(err.Message)
+		}
+		errCount += len(errs)
+	})
+	if errCount != 0 {
+		t.Errorf("Failed to correct type checker errors; have %d errors", errCount)
+	}
+
+	usagePosition := &token.Position{
+		Filename: "/go/src/foo/foo1.go",
+		Line:     3,
+		Column:   3,
+	}
+	declPosition, err := w.LocateDeclaration(usagePosition)
+	if err != nil {
+		t.Fatalf("Error while finding declaration: %s", err.Error())
+	}
+	if declPosition == nil {
+		t.Fatalf("declPosition is nil")
+	}
+	if !declPosition.IsValid() {
+		t.Fatalf("declPosition is not valid")
+	}
+	if declPosition.Filename != "/go/src/foo/foo2.go" {
+		t.Fatalf("Incorrect filename: '%s'", declPosition.Filename)
+	}
+}

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/token"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -168,7 +169,7 @@ func setup(t *testing.T) *Workspace {
 		loader.LoadDirectory("/go/src/foo")
 		<-done
 
-		w.AssignAST()
+		// w.AssignAST()
 
 		errCount := 0
 		w.Loader.Errors(func(file string, errs []FileError) {
@@ -229,7 +230,17 @@ func nthIndex(s string, sub string, n int) int {
 }
 
 func nthIndex2(w *Workspace, path, s, sub string, n int) int {
-	astFile, ok := w.Files[path]
+	absPath := filepath.Dir(path)
+
+	node, ok := w.Loader.caravan.Find(absPath)
+	if !ok {
+		// This is a problem.
+	}
+	pkg := node.Element.(*Package)
+	fi := pkg.files[filepath.Base(path)]
+	astFile := fi.file
+
+	// astFile, ok := w.Files[path]
 	if !ok {
 		panic(fmt.Sprintf("No ast.File at %s\n", path))
 	}

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -1,256 +1,86 @@
 package langd
 
+// workspace_test.go does not contain actual tests, but rather utility
+// functions that support testing workspace methods.
+
 import (
+	"bytes"
+	"fmt"
+	"go/token"
 	"os"
-	"strings"
-	"sync"
 	"testing"
 
 	"github.com/object88/langd/log"
 	"golang.org/x/tools/go/buildutil"
 )
 
-const identTestProgram = `package foo
+func workspaceSetup(t *testing.T, startingPath string, packages map[string]map[string]string, expectFailure bool) *Workspace {
+	fc := buildutil.FakeContext(packages)
+	loader := NewLoader(func(l *Loader) {
+		l.context = fc
+	})
+	w := CreateWorkspace(loader, log.CreateLog(os.Stdout))
+	w.log.SetLevel(log.Verbose)
 
-var calls = map[string]int{}
-var totalCalls = 0
+	done := loader.Start()
+	loader.LoadDirectory(startingPath)
+	<-done
 
-func add1(add1Param1 int) int {
-	countCall("add1")
-
-	add1result := add1Param1
-	add1result++
-	return add1result
-}
-
-func countCall(source string) {
-	totalCalls++
-
-	call, ok := calls[source]
-	if !ok {
-		call = 1
-	} else {
-		call++
-	}
-	calls[source] = call
-}
-
-func addWhilePos(addWhilePosParam1, addWhilePosParam2 int) int {
-	if addWhilePosParam2 == 0 {
-		return addWhilePosParam1
-	}
-	return addWhilePos(addWhilePosParam1 + 1, addWhilePosParam2 - 1)
-}
-`
-
-// func Test_LocateIdent_OnIdent(t *testing.T) {
-// 	identName := "add1result"
-// 	w := setup(t)
-
-// 	tests := []struct {
-// 		name   string
-// 		offset int
-// 	}{
-// 		{
-// 			name:   "AtStart",
-// 			offset: 0,
-// 		},
-// 		{
-// 			name:   "Within",
-// 			offset: 2,
-// 		},
-// 		{
-// 			name:   "AtEnd",
-// 			offset: len(identName) - 1,
-// 		},
-// 	}
-
-// 	for _, tc := range tests {
-// 		t.Run(tc.name, func(t *testing.T) {
-// 			offset := nthIndex(identTestProgram, identName, 0)
-// 			pos := offset + 1
-
-// 			p := w.Loader.Fset.Position(token.Pos(pos + tc.offset))
-// 			ident, err := w.LocateIdent(&p)
-// 			if err != nil {
-// 				t.Errorf("Got error: %s", err.Error())
-// 			}
-// 			if ident == nil {
-// 				t.Errorf("Did not get ident back")
-// 			}
-// 			if int(ident.Pos()) != pos {
-// 				t.Errorf("Ident is at wrong position: got %d; expected %d", ident.Pos(), pos)
-// 			}
-// 			if ident.Name != identName {
-// 				t.Errorf("Ident has wrong name; got '%s'; expected '%s'", ident.Name, identName)
-// 			}
-// 		})
-// 	}
-// }
-
-// func Test_LocateIdent_OnKeyword(t *testing.T) {
-// 	identName := "func"
-// 	w := setup(t)
-
-// 	offset := nthIndex(identTestProgram, identName, 0)
-// 	pos := offset + 1
-
-// 	p := w.Loader.Fset.Position(token.Pos(pos))
-// 	ident, err := w.LocateIdent(&p)
-// 	if err != nil {
-// 		t.Errorf("Got error: %s", err.Error())
-// 	}
-// 	if ident != nil {
-// 		t.Errorf("Got ident back at %d", ident.Pos())
-// 	}
-// }
-
-// func Test_LocateReferences(t *testing.T) {
-// 	w := setup(t)
-
-// 	identName := "add1result"
-// 	offset := nthIndex(identTestProgram, identName, 0)
-
-// 	// Find an ident a couple of characters into the word
-// 	// Must add 1, then nudging in 2 characters.
-// 	p := w.Loader.Fset.Position(token.Pos(offset + 3))
-// 	fmt.Printf("p: %#v\n", p)
-// 	ident, _ := w.LocateIdent(&p)
-// 	if ident == nil {
-// 		t.Fatalf("Did not get ident back")
-// 	}
-
-// 	refPositions := w.LocateReferences(ident)
-// 	if nil == refPositions {
-// 		t.Errorf("Did not get any references back")
-// 	}
-
-// 	expectedOffsets := []int{
-// 		nthIndex(identTestProgram, identName, 1),
-// 		nthIndex(identTestProgram, identName, 2),
-// 	}
-
-// 	for _, v := range *refPositions {
-// 		found := false
-// 		for _, v2 := range expectedOffsets {
-// 			if v.Offset == v2 {
-// 				found = true
-// 				break
-// 			}
-// 		}
-// 		if !found {
-// 			t.Errorf("Got refPosition %d is not among expected offsets", v.Offset)
-// 		}
-// 	}
-// }
-
-var _o sync.Once
-var _w *Workspace
-
-func setup(t *testing.T) *Workspace {
-	_o.Do(func() {
-		packages := map[string]map[string]string{
-			"foo": map[string]string{
-				"foo.go": identTestProgram,
-			},
-		}
-
-		fc := buildutil.FakeContext(packages)
-		loader := NewLoader(func(l *Loader) {
-			l.context = fc
-		})
-		w := CreateWorkspace(loader, log.CreateLog(os.Stdout))
-		w.log.SetLevel(log.Verbose)
-
-		done := loader.Start()
-		loader.LoadDirectory("/go/src/foo")
-		<-done
-
-		// w.AssignAST()
-
+	if expectFailure {
 		errCount := 0
 		w.Loader.Errors(func(file string, errs []FileError) {
-			if errCount == 0 {
-				t.Errorf("Loading error in %s:\n", file)
-			}
+			errCount += len(errs)
+		})
+		if errCount == 0 {
+			t.Fatal("Expected errors, but got none\n")
+		}
+	} else {
+		errCount := 0
+		var buf bytes.Buffer
+		w.Loader.Errors(func(file string, errs []FileError) {
+			buf.WriteString(fmt.Sprintf("Loading error in %s:\n", file))
 			for k, err := range errs {
-				t.Errorf("\t%d: %s\n", k, err.Message)
+				buf.WriteString(fmt.Sprintf("\t%02d: %s:%d %s\n", k, err.Filename, err.Line, err.Message))
 			}
-			errCount++
+			errCount += len(errs)
 		})
 
 		if errCount != 0 {
-			t.Fatalf("Found %d errors", errCount)
+			buf.WriteString(fmt.Sprintf("Total: %d errors\n", errCount))
+			t.Fatal(buf.String())
 		}
+	}
 
-		_w = w
-	})
-
-	return _w
+	return w
 }
 
-func Test_nthIndex(t *testing.T) {
-	//    0123456789
-	s := "abcdefghijabcdefghijabcdefghij"
-	x := nthIndex(s, "x", 0)
-	if -1 != x {
-		t.Errorf("Failed to return -1 for absent substring; got %d.", x)
+func testDeclaration(t *testing.T, w *Workspace, usagePosition, expectedDeclPosition *token.Position) {
+	declPosition, err := w.LocateDeclaration(usagePosition)
+	if err != nil {
+		t.Fatal(err.Error())
 	}
 
-	x = nthIndex(s, "abc", 0)
-	if 0 != x {
-		t.Errorf("Failed to return 0 for first instance of substring; got %d.", x)
-	}
-
-	x = nthIndex(s, "abc", 1)
-	if 10 != x {
-		t.Errorf("Failed to return 10 for second instance of substring; got %d.", x)
-	}
-
-	x = nthIndex(s, "abc", 2)
-	if 20 != x {
-		t.Errorf("Failed to return 20 for third instance of substring; got %d.", x)
-	}
+	comparePosition(t, declPosition, expectedDeclPosition)
 }
 
-func nthIndex(s string, sub string, n int) int {
-	offset := 0
-	for i := 0; i < n; i++ {
-		loc := strings.Index(s, sub)
-		if loc == -1 {
-			return loc
-		}
-		offset += loc + 1
-		s = s[loc+1:]
+func comparePosition(t *testing.T, actual, expected *token.Position) {
+	if actual == nil {
+		t.Fatalf("actual is nil")
 	}
-	return offset + strings.Index(s, sub)
+
+	if !actual.IsValid() {
+		t.Fatalf("Returned position '%s' is not valid", actual.String())
+	}
+
+	if actual.Filename != expected.Filename {
+		t.Fatalf("Incorrect filename: got '%s', expected '%s'", actual.Filename, expected.Filename)
+	}
+
+	if actual.Line != expected.Line {
+		t.Fatalf("Incorrect line: got %d, expected %d", actual.Line, expected.Line)
+	}
+
+	if actual.Column != expected.Column {
+		t.Fatalf("Incorrect column: got %d, expected %d", actual.Column, expected.Column)
+	}
 }
-
-// func nthIndex2(w *Workspace, path, s, sub string, n int) int {
-// 	absPath := filepath.Dir(path)
-
-// 	node, ok := w.Loader.caravan.Find(absPath)
-// 	if !ok {
-// 		// This is a problem.
-// 	}
-// 	pkg := node.Element.(*Package)
-// 	fi := pkg.files[filepath.Base(path)]
-// 	astFile := fi.file
-
-// 	// astFile, ok := w.Files[path]
-// 	if !ok {
-// 		panic(fmt.Sprintf("No ast.File at %s\n", path))
-// 	}
-// 	w.Loader.Fset.Position(astFile.Pos())
-
-// 	offset := 0
-// 	for i := 0; i < n; i++ {
-// 		loc := strings.Index(s, sub)
-// 		if loc == -1 {
-// 			return loc
-// 		}
-// 		offset += loc + 1
-// 		s = s[loc+1:]
-// 	}
-// 	return offset + strings.Index(s, sub)
-// }

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -1,10 +1,7 @@
 package langd
 
 import (
-	"fmt"
-	"go/token"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -46,106 +43,106 @@ func addWhilePos(addWhilePosParam1, addWhilePosParam2 int) int {
 }
 `
 
-func Test_LocateIdent_OnIdent(t *testing.T) {
-	identName := "add1result"
-	w := setup(t)
+// func Test_LocateIdent_OnIdent(t *testing.T) {
+// 	identName := "add1result"
+// 	w := setup(t)
 
-	tests := []struct {
-		name   string
-		offset int
-	}{
-		{
-			name:   "AtStart",
-			offset: 0,
-		},
-		{
-			name:   "Within",
-			offset: 2,
-		},
-		{
-			name:   "AtEnd",
-			offset: len(identName) - 1,
-		},
-	}
+// 	tests := []struct {
+// 		name   string
+// 		offset int
+// 	}{
+// 		{
+// 			name:   "AtStart",
+// 			offset: 0,
+// 		},
+// 		{
+// 			name:   "Within",
+// 			offset: 2,
+// 		},
+// 		{
+// 			name:   "AtEnd",
+// 			offset: len(identName) - 1,
+// 		},
+// 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			offset := nthIndex(identTestProgram, identName, 0)
-			pos := offset + 1
+// 	for _, tc := range tests {
+// 		t.Run(tc.name, func(t *testing.T) {
+// 			offset := nthIndex(identTestProgram, identName, 0)
+// 			pos := offset + 1
 
-			p := w.Loader.Fset.Position(token.Pos(pos + tc.offset))
-			ident, err := w.LocateIdent(&p)
-			if err != nil {
-				t.Errorf("Got error: %s", err.Error())
-			}
-			if ident == nil {
-				t.Errorf("Did not get ident back")
-			}
-			if int(ident.Pos()) != pos {
-				t.Errorf("Ident is at wrong position: got %d; expected %d", ident.Pos(), pos)
-			}
-			if ident.Name != identName {
-				t.Errorf("Ident has wrong name; got '%s'; expected '%s'", ident.Name, identName)
-			}
-		})
-	}
-}
+// 			p := w.Loader.Fset.Position(token.Pos(pos + tc.offset))
+// 			ident, err := w.LocateIdent(&p)
+// 			if err != nil {
+// 				t.Errorf("Got error: %s", err.Error())
+// 			}
+// 			if ident == nil {
+// 				t.Errorf("Did not get ident back")
+// 			}
+// 			if int(ident.Pos()) != pos {
+// 				t.Errorf("Ident is at wrong position: got %d; expected %d", ident.Pos(), pos)
+// 			}
+// 			if ident.Name != identName {
+// 				t.Errorf("Ident has wrong name; got '%s'; expected '%s'", ident.Name, identName)
+// 			}
+// 		})
+// 	}
+// }
 
-func Test_LocateIdent_OnKeyword(t *testing.T) {
-	identName := "func"
-	w := setup(t)
+// func Test_LocateIdent_OnKeyword(t *testing.T) {
+// 	identName := "func"
+// 	w := setup(t)
 
-	offset := nthIndex(identTestProgram, identName, 0)
-	pos := offset + 1
+// 	offset := nthIndex(identTestProgram, identName, 0)
+// 	pos := offset + 1
 
-	p := w.Loader.Fset.Position(token.Pos(pos))
-	ident, err := w.LocateIdent(&p)
-	if err != nil {
-		t.Errorf("Got error: %s", err.Error())
-	}
-	if ident != nil {
-		t.Errorf("Got ident back at %d", ident.Pos())
-	}
-}
+// 	p := w.Loader.Fset.Position(token.Pos(pos))
+// 	ident, err := w.LocateIdent(&p)
+// 	if err != nil {
+// 		t.Errorf("Got error: %s", err.Error())
+// 	}
+// 	if ident != nil {
+// 		t.Errorf("Got ident back at %d", ident.Pos())
+// 	}
+// }
 
-func Test_LocateReferences(t *testing.T) {
-	w := setup(t)
+// func Test_LocateReferences(t *testing.T) {
+// 	w := setup(t)
 
-	identName := "add1result"
-	offset := nthIndex(identTestProgram, identName, 0)
+// 	identName := "add1result"
+// 	offset := nthIndex(identTestProgram, identName, 0)
 
-	// Find an ident a couple of characters into the word
-	// Must add 1, then nudging in 2 characters.
-	p := w.Loader.Fset.Position(token.Pos(offset + 3))
-	fmt.Printf("p: %#v\n", p)
-	ident, _ := w.LocateIdent(&p)
-	if ident == nil {
-		t.Fatalf("Did not get ident back")
-	}
+// 	// Find an ident a couple of characters into the word
+// 	// Must add 1, then nudging in 2 characters.
+// 	p := w.Loader.Fset.Position(token.Pos(offset + 3))
+// 	fmt.Printf("p: %#v\n", p)
+// 	ident, _ := w.LocateIdent(&p)
+// 	if ident == nil {
+// 		t.Fatalf("Did not get ident back")
+// 	}
 
-	refPositions := w.LocateReferences(ident)
-	if nil == refPositions {
-		t.Errorf("Did not get any references back")
-	}
+// 	refPositions := w.LocateReferences(ident)
+// 	if nil == refPositions {
+// 		t.Errorf("Did not get any references back")
+// 	}
 
-	expectedOffsets := []int{
-		nthIndex(identTestProgram, identName, 1),
-		nthIndex(identTestProgram, identName, 2),
-	}
+// 	expectedOffsets := []int{
+// 		nthIndex(identTestProgram, identName, 1),
+// 		nthIndex(identTestProgram, identName, 2),
+// 	}
 
-	for _, v := range *refPositions {
-		found := false
-		for _, v2 := range expectedOffsets {
-			if v.Offset == v2 {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("Got refPosition %d is not among expected offsets", v.Offset)
-		}
-	}
-}
+// 	for _, v := range *refPositions {
+// 		found := false
+// 		for _, v2 := range expectedOffsets {
+// 			if v.Offset == v2 {
+// 				found = true
+// 				break
+// 			}
+// 		}
+// 		if !found {
+// 			t.Errorf("Got refPosition %d is not among expected offsets", v.Offset)
+// 		}
+// 	}
+// }
 
 var _o sync.Once
 var _w *Workspace
@@ -229,31 +226,31 @@ func nthIndex(s string, sub string, n int) int {
 	return offset + strings.Index(s, sub)
 }
 
-func nthIndex2(w *Workspace, path, s, sub string, n int) int {
-	absPath := filepath.Dir(path)
+// func nthIndex2(w *Workspace, path, s, sub string, n int) int {
+// 	absPath := filepath.Dir(path)
 
-	node, ok := w.Loader.caravan.Find(absPath)
-	if !ok {
-		// This is a problem.
-	}
-	pkg := node.Element.(*Package)
-	fi := pkg.files[filepath.Base(path)]
-	astFile := fi.file
+// 	node, ok := w.Loader.caravan.Find(absPath)
+// 	if !ok {
+// 		// This is a problem.
+// 	}
+// 	pkg := node.Element.(*Package)
+// 	fi := pkg.files[filepath.Base(path)]
+// 	astFile := fi.file
 
-	// astFile, ok := w.Files[path]
-	if !ok {
-		panic(fmt.Sprintf("No ast.File at %s\n", path))
-	}
-	w.Loader.Fset.Position(astFile.Pos())
+// 	// astFile, ok := w.Files[path]
+// 	if !ok {
+// 		panic(fmt.Sprintf("No ast.File at %s\n", path))
+// 	}
+// 	w.Loader.Fset.Position(astFile.Pos())
 
-	offset := 0
-	for i := 0; i < n; i++ {
-		loc := strings.Index(s, sub)
-		if loc == -1 {
-			return loc
-		}
-		offset += loc + 1
-		s = s[loc+1:]
-	}
-	return offset + strings.Index(s, sub)
-}
+// 	offset := 0
+// 	for i := 0; i < n; i++ {
+// 		loc := strings.Index(s, sub)
+// 		if loc == -1 {
+// 			return loc
+// 		}
+// 		offset += loc + 1
+// 		s = s[loc+1:]
+// 	}
+// 	return offset + strings.Index(s, sub)
+// }


### PR DESCRIPTION
Start to track edits.  After file is edited, recompile the AST and re-run type checker on relevant files.