### PR TITLE
Implement "locate references" functionality

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -285,7 +285,7 @@ func (l *Loader) Errors(handleErrs func(file string, errs []FileError)) {
 // LoadDirectory adds the contents of a directory to the Loader
 func (l *Loader) LoadDirectory(absPath string) error {
 	if !l.context.IsDir(absPath) {
-		return fmt.Errorf("Argument '%s' is not a directory\n", absPath)
+		return fmt.Errorf("Argument '%s' is not a directory", absPath)
 	}
 
 	l.startDir = absPath

--- a/references.go
+++ b/references.go
@@ -36,6 +36,26 @@ func (w *Workspace) locateReferences(obj types.Object, pkg *Package) []*ref {
 			})
 		}
 	}
+
+	if obj.Exported() {
+		n, ok := w.Loader.caravan.Find(pkg.absPath)
+		if !ok {
+			// Should never get here.
+			panic("Shit.")
+		}
+		for _, n1 := range n.Ascendants {
+			pkg1 := n1.Element.(*Package)
+			for id, use := range pkg1.checker.Uses {
+				if sameObj(obj, use) {
+					refs = append(refs, &ref{
+						pkg: pkg1,
+						pos: id.Pos(),
+					})
+				}
+			}
+		}
+	}
+
 	return refs
 }
 

--- a/references.go
+++ b/references.go
@@ -1,8 +1,11 @@
 package langd
 
 import (
+	"fmt"
 	"go/token"
 	"go/types"
+
+	"github.com/object88/langd/collections"
 )
 
 type ref struct {
@@ -43,19 +46,37 @@ func (w *Workspace) locateReferences(obj types.Object, pkg *Package) []*ref {
 			// Should never get here.
 			panic("Shit.")
 		}
-		for _, n1 := range n.Ascendants {
-			pkg1 := n1.Element.(*Package)
-			for id, use := range pkg1.checker.Uses {
-				if sameObj(obj, use) {
-					refs = append(refs, &ref{
-						pkg: pkg1,
-						pos: id.Pos(),
-					})
-				}
-			}
-		}
+		fmt.Printf("obj: %#v\n", obj)
+		refs = checkAscendants(refs, n, obj)
+		// for _, n1 := range n.Ascendants {
+		// 	pkg1 := n1.Element.(*Package)
+		// 	for id, use := range pkg1.checker.Uses {
+		// 		if sameObj(obj, use) {
+		// 			refs = append(refs, &ref{
+		// 				pkg: pkg1,
+		// 				pos: id.Pos(),
+		// 			})
+		// 		}
+		// 	}
+		// }
 	}
 
+	return refs
+}
+
+func checkAscendants(refs []*ref, n *collections.Node, obj types.Object) []*ref {
+	for _, n1 := range n.Ascendants {
+		pkg1 := n1.Element.(*Package)
+		for id, use := range pkg1.checker.Uses {
+			if sameObj(obj, use) {
+				refs = append(refs, &ref{
+					pkg: pkg1,
+					pos: id.Pos(),
+				})
+			}
+		}
+		refs = checkAscendants(refs, n1, obj)
+	}
 	return refs
 }
 

--- a/references.go
+++ b/references.go
@@ -48,17 +48,6 @@ func (w *Workspace) locateReferences(obj types.Object, pkg *Package) []*ref {
 		}
 		fmt.Printf("obj: %#v\n", obj)
 		refs = checkAscendants(refs, n, obj)
-		// for _, n1 := range n.Ascendants {
-		// 	pkg1 := n1.Element.(*Package)
-		// 	for id, use := range pkg1.checker.Uses {
-		// 		if sameObj(obj, use) {
-		// 			refs = append(refs, &ref{
-		// 				pkg: pkg1,
-		// 				pos: id.Pos(),
-		// 			})
-		// 		}
-		// 	}
-		// }
 	}
 
 	return refs

--- a/references.go
+++ b/references.go
@@ -1,0 +1,57 @@
+package langd
+
+import (
+	"go/token"
+	"go/types"
+)
+
+type ref struct {
+	pkg *Package
+	pos token.Pos
+}
+
+// func (w *Workspace) locateReferences(ident *ast.Ident, pkg *Package) []*ref {
+func (w *Workspace) locateReferences(obj types.Object, pkg *Package) []*ref {
+	// obj := pkg.checker.ObjectOf(ident)
+	if obj == nil {
+		// Special case
+	}
+
+	// If this is a package name, do something special also.
+	if _, ok := obj.(*types.PkgName); ok {
+		// *shrug*
+	}
+
+	if obj.Pkg() == nil {
+		// Uhhh, not sure what this is?  A keyword or something?
+	}
+
+	// Start off with in-package references, shall we?
+	var refs []*ref
+	for id, use := range pkg.checker.Uses {
+		if sameObj(obj, use) {
+			refs = append(refs, &ref{
+				pkg: pkg,
+				pos: id.Pos(),
+			})
+		}
+	}
+	return refs
+}
+
+func sameObj(x, y types.Object) bool {
+	if x == y {
+		return true
+	}
+
+	xPkgname, ok := x.(*types.PkgName)
+	if !ok {
+		return false
+	}
+	yPkgname, ok := y.(*types.PkgName)
+	if !ok {
+		return false
+	}
+
+	return xPkgname.Imported() == yPkgname.Imported()
+}

--- a/requests/handler.go
+++ b/requests/handler.go
@@ -71,7 +71,7 @@ func NewHandler() *Handler {
 		rm: map[int]requestHandler{},
 		sq: sq,
 
-		rq: newRequestMap(),
+		rq: newRequestMap(getIniterFuncs()),
 
 		log:       l,
 		workspace: langd.CreateWorkspace(loader, l),

--- a/requests/references.go
+++ b/requests/references.go
@@ -85,16 +85,16 @@ func (rh *referencesHandler) work() error {
 	if err != nil {
 		fmt.Printf("Failed to find declaration position: %s\n", err.Error())
 	}
-	declIdent, err := rh.h.workspace.LocateIdent(declPosition)
-	if err != nil {
-		fmt.Printf("Failed to find ident: %s\n", err.Error())
-	}
+	// declIdent, err := rh.h.workspace.LocateIdent(declPosition)
+	// if err != nil {
+	// 	fmt.Printf("Failed to find ident: %s\n", err.Error())
+	// }
 
-	usePositions := rh.h.workspace.LocateReferences(declIdent)
+	usePositions := rh.h.workspace.LocateReferences(rh.p)
 
 	size := 0
-	if usePositions != nil && len(*usePositions) > 0 {
-		size = len(*usePositions)
+	if usePositions != nil && len(usePositions) > 0 {
+		size = len(usePositions)
 	}
 
 	if rh.options.IncludeDeclaration {
@@ -117,7 +117,7 @@ func (rh *referencesHandler) work() error {
 		offset = 1
 	}
 	if usePositions != nil {
-		for k, v := range *usePositions {
+		for k, v := range usePositions {
 			fmt.Printf("\t%d: %v\n", k, v)
 			locs[k+offset] = *LocationFromPosition(x.Name, &v)
 		}

--- a/requests/references.go
+++ b/requests/references.go
@@ -85,10 +85,6 @@ func (rh *referencesHandler) work() error {
 	if err != nil {
 		fmt.Printf("Failed to find declaration position: %s\n", err.Error())
 	}
-	// declIdent, err := rh.h.workspace.LocateIdent(declPosition)
-	// if err != nil {
-	// 	fmt.Printf("Failed to find ident: %s\n", err.Error())
-	// }
 
 	usePositions := rh.h.workspace.LocateReferences(rh.p)
 
@@ -122,10 +118,6 @@ func (rh *referencesHandler) work() error {
 			locs[k+offset] = *LocationFromPosition(x.Name, &v)
 		}
 	}
-
-	// fmt.Printf("X:\n%#v\n", x.Obj)
-	// foo := rh.h.workspace.Info.Uses[x]
-	// fmt.Printf("Uses:\n%#v\n", foo)
 
 	rh.result = &locs
 

--- a/requests/requestMap.go
+++ b/requests/requestMap.go
@@ -10,9 +10,7 @@ type requestMap struct {
 	f []IniterFunc
 }
 
-func newRequestMap() *requestMap {
-	m := getIniterFuncs()
-
+func newRequestMap(m initerFuncMap) *requestMap {
 	keys := make([]string, len(m))
 	funcs := make([]IniterFunc, len(m))
 

--- a/workspace.go
+++ b/workspace.go
@@ -484,23 +484,23 @@ func (w *Workspace) locateDeclaration(p *token.Position) (types.Object, *Package
 					return oooo, pkg1, nil
 				}
 
-				selIdent := ast.NewIdent(v.Sel.Name)
-				fmt.Printf("Using new ident %#v\n", selIdent)
-				def, ok := pkg1.checker.Defs[selIdent]
-				if !ok {
-					fmt.Printf("Not from Defs\n")
-				} else {
-					fmt.Printf("From defs: %#v\n", def)
-					// declPos := pkg1.Fset.Position(def.Pos())
-					return def, pkg1, nil
-				}
+				// selIdent := ast.NewIdent(v.Sel.Name)
+				// fmt.Printf("Using new ident %#v\n", selIdent)
+				// def, ok := pkg1.checker.Defs[selIdent]
+				// if !ok {
+				// 	fmt.Printf("Not from Defs\n")
+				// } else {
+				// 	fmt.Printf("From defs: %#v\n", def)
+				// 	// declPos := pkg1.Fset.Position(def.Pos())
+				// 	return def, pkg1, nil
+				// }
 			case *types.Var:
-				fmt.Printf("Have Var %s, type %s\n\t%#v\n\tSel: %#v\n", v1.Name(), v1.Type(), v1, v.Sel)
-				sel := pkg.checker.Selections[v]
-				fmt.Printf("Sel: %#v\n", sel)
-				if sel != nil {
-					return sel.Obj(), pkg, nil
-				}
+				fmt.Printf("Have Var %s, type %s\n\tv1: %#v\n\tv1.Sel: %#v\n", v1.Name(), v1.Type(), v1, v.Sel)
+				vSelObj := pkg.checker.ObjectOf(v.Sel)
+				path := vSelObj.Pkg().Path()
+				n, _ := w.Loader.caravan.Find(path)
+				pkg1 := n.Element.(*Package)
+				return vSelObj, pkg1, nil
 			}
 		}
 

--- a/workspace.go
+++ b/workspace.go
@@ -494,6 +494,13 @@ func (w *Workspace) locateDeclaration(p *token.Position) (types.Object, *Package
 					// declPos := pkg1.Fset.Position(def.Pos())
 					return def, pkg1, nil
 				}
+			case *types.Var:
+				fmt.Printf("Have Var %s, type %s\n\t%#v\n\tSel: %#v\n", v1.Name(), v1.Type(), v1, v.Sel)
+				sel := pkg.checker.Selections[v]
+				fmt.Printf("Sel: %#v\n", sel)
+				if sel != nil {
+					return sel.Obj(), pkg, nil
+				}
 			}
 		}
 

--- a/workspace.go
+++ b/workspace.go
@@ -420,92 +420,147 @@ func (w *Workspace) locateDeclaration(p *token.Position) (types.Object, *Package
 		return nil, nil, nil
 	}
 
+	return w.xyz(x, pkg)
+
+	// switch v := x.(type) {
+	// case *ast.Ident:
+	// 	fmt.Printf("Have ident %#v\n", v)
+	// 	if v.Obj != nil {
+	// 		fmt.Printf("Ident has obj %#v (%d)\n", v.Obj, v.Pos())
+	// 		vObj := pkg.checker.ObjectOf(v)
+	// 		return vObj, pkg, nil
+	// 	}
+	// 	if vDef, ok := pkg.checker.Defs[v]; ok {
+	// 		fmt.Printf("Have vDef from Defs: %#v\n", vDef)
+	// 		return vDef, pkg, nil
+	// 	}
+	// 	if vUse, ok := pkg.checker.Uses[v]; ok {
+	// 		// Used when var is defined in a package, in another file
+	// 		fmt.Printf("Have vUse from Uses: %#v\n", vUse)
+	// 		return vUse, pkg, nil
+	// 	}
+
+	// case *ast.SelectorExpr:
+	// 	fmt.Printf("Have SelectorExpr\n")
+
+	// 	switch vX := v.X.(type) {
+	// 	case *ast.Ident:
+	// 		vXObj := pkg.checker.ObjectOf(vX)
+	// 		if vXObj == nil {
+	// 			return nil, nil, fmt.Errorf("v.X (%s) not in ObjectOf", vX.Name)
+	// 		}
+	// 		fmt.Printf("checker.ObjectOf(v.X): %#v\n", vXObj)
+	// 		switch v1 := vXObj.(type) {
+	// 		case *types.PkgName:
+	// 			fmt.Printf("Have PkgName %s, type %s\n", v1.Name(), v1.Type())
+	// 			absPath := v1.Imported().Path()
+	// 			n, _ := w.Loader.caravan.Find(absPath)
+	// 			pkg1 := n.Element.(*Package)
+	// 			fmt.Printf("From pkg %#v\n", pkg1)
+
+	// 			oooo := pkg1.typesPkg.Scope().Lookup(v.Sel.Name)
+	// 			if oooo != nil {
+	// 				return oooo, pkg1, nil
+	// 			}
+
+	// 		case *types.Var:
+	// 			fmt.Printf("Have Var %s, type %s\n\tv1: %#v\n\tv1.Sel: %#v\n", v1.Name(), v1.Type(), v1, v.Sel)
+	// 			vSelObj := pkg.checker.ObjectOf(v.Sel)
+	// 			path := vSelObj.Pkg().Path()
+	// 			n, _ := w.Loader.caravan.Find(path)
+	// 			pkg1 := n.Element.(*Package)
+	// 			return vSelObj, pkg1, nil
+	// 		}
+	// 	case *ast.SelectorExpr:
+	// 		fmt.Printf("vX.(*ast.SelectorExpr): %#v\n", vX)
+	// 		fmt.Printf("vX.(*ast.SelectorExpr).X.(*ast.Ident): %#v\n", vX.X.(*ast.Ident))
+	// 		fmt.Printf("pkg.checker.ObjectOf(vX.(*ast.SelectorExpr).X.(*ast.Ident)): %#v\n", pkg.checker.ObjectOf(vX.X.(*ast.Ident)))
+	// 		fmt.Printf("vX.(*ast.SelectorExpr).Sel: %#v\n", vX.Sel)
+	// 		fmt.Printf("pkg.checker.ObjectOf(vX.(*ast.SelectorExpr).Sel): %#v\n", pkg.checker.ObjectOf(vX.Sel))
+	// 		fmt.Printf("\n")
+	// 		fmt.Printf(
+	// 			"pkg.checker.ObjectOf(vX.Sel).Type().(*types.Pointer).Elem().(*types.Named).Obj():\n\t%#v\n",
+	// 			pkg.checker.ObjectOf(vX.Sel).Type().(*types.Pointer).Elem().(*types.Named).Obj())
+
+	// 		vSelObj := pkg.checker.ObjectOf(vX.Sel)
+	// 		path := vSelObj.Pkg().Path()
+	// 		n, _ := w.Loader.caravan.Find(path)
+	// 		pkg1 := n.Element.(*Package)
+	// 		return vSelObj, pkg1, nil
+	// 	}
+
+	// default:
+	// 	fmt.Printf("Is %#v\n", x)
+	// }
+	// return nil, nil, nil
+}
+
+func (w *Workspace) xyz(x ast.Node, pkg *Package) (types.Object, *Package, error) {
 	switch v := x.(type) {
 	case *ast.Ident:
 		fmt.Printf("Have ident %#v\n", v)
 		if v.Obj != nil {
 			fmt.Printf("Ident has obj %#v (%d)\n", v.Obj, v.Pos())
-			// identPosition := pkg.Fset.Position(v.Obj.Pos())
 			vObj := pkg.checker.ObjectOf(v)
 			return vObj, pkg, nil
 		}
-		// xObj := pkg.info.ObjectOf(v)
-		// if xObj != nil {
-		// 	identPosition := w.Loader.Fset.Position(xObj.Pos())
-		// 	return &identPosition, nil
-		// }
 		if vDef, ok := pkg.checker.Defs[v]; ok {
 			fmt.Printf("Have vDef from Defs: %#v\n", vDef)
-			// identPosition := pkg.Fset.Position(vDef.Pos())
 			return vDef, pkg, nil
 		}
 		if vUse, ok := pkg.checker.Uses[v]; ok {
 			// Used when var is defined in a package, in another file
 			fmt.Printf("Have vUse from Uses: %#v\n", vUse)
-			vUseScope := vUse.Parent()
-			vScopedObj := vUseScope.Lookup(vUse.Name())
-			fmt.Printf("vUseScopedObj: %#v\n", vScopedObj)
-			// identPosition := pkg.Fset.Position(vUse.Pos())
-
 			return vUse, pkg, nil
-
-			// switch v1 := vUse.(type) {
-			// case *types.Var:
-			// 	scope := v1.Parent()
-			// 	scopedObj := scope.Lookup(v.Name)
-			// 	identPosition := w.Loader.Fset.Position(scopedObj.Pos())
-			// 	return &identPosition, nil
-			// }
 		}
 
 	case *ast.SelectorExpr:
-		fmt.Printf("Have SelectorExpr\n")
-
-		scopedObj := f.Scope.Lookup(v.X.(*ast.Ident).Name)
-		fmt.Printf("Scoped object... %#v\n", scopedObj)
-
-		vXObj := pkg.checker.ObjectOf(v.X.(*ast.Ident))
-		if vXObj == nil {
-			fmt.Printf("v.X not in ObjectOf\n")
-		} else {
-			fmt.Printf("checker.ObjectOf(v.X): %#v\n", vXObj)
-			switch v1 := vXObj.(type) {
-			case *types.PkgName:
-				fmt.Printf("Have PkgName %s, type %s\n", v1.Name(), v1.Type())
-				absPath := v1.Imported().Path()
-				e, _ := w.Loader.caravan.Find(absPath)
-				pkg1 := e.Element.(*Package)
-				fmt.Printf("From pkg %#v\n", pkg1)
-
-				oooo := pkg1.typesPkg.Scope().Lookup(v.Sel.Name)
-				if oooo != nil {
-					// Have thingy from scope!
-					// declPos := pkg1.Fset.Position(oooo.Pos())
-					return oooo, pkg1, nil
-				}
-
-				// selIdent := ast.NewIdent(v.Sel.Name)
-				// fmt.Printf("Using new ident %#v\n", selIdent)
-				// def, ok := pkg1.checker.Defs[selIdent]
-				// if !ok {
-				// 	fmt.Printf("Not from Defs\n")
-				// } else {
-				// 	fmt.Printf("From defs: %#v\n", def)
-				// 	// declPos := pkg1.Fset.Position(def.Pos())
-				// 	return def, pkg1, nil
-				// }
-			case *types.Var:
-				fmt.Printf("Have Var %s, type %s\n\tv1: %#v\n\tv1.Sel: %#v\n", v1.Name(), v1.Type(), v1, v.Sel)
-				vSelObj := pkg.checker.ObjectOf(v.Sel)
-				path := vSelObj.Pkg().Path()
-				n, _ := w.Loader.caravan.Find(path)
-				pkg1 := n.Element.(*Package)
-				return vSelObj, pkg1, nil
-			}
-		}
+		return w.processSelectorExpr(v, pkg)
 
 	default:
 		fmt.Printf("Is %#v\n", x)
 	}
+
+	return nil, nil, nil
+}
+
+func (w *Workspace) processSelectorExpr(v *ast.SelectorExpr, pkg *Package) (types.Object, *Package, error) {
+	fmt.Printf("Have SelectorExpr\n")
+	switch vX := v.X.(type) {
+	case *ast.Ident:
+		vXObj := pkg.checker.ObjectOf(vX)
+		if vXObj == nil {
+			return nil, nil, fmt.Errorf("v.X (%s) not in ObjectOf", vX.Name)
+		}
+		fmt.Printf("checker.ObjectOf(v.X): %#v\n", vXObj)
+		switch v1 := vXObj.(type) {
+		case *types.PkgName:
+			fmt.Printf("Have PkgName %s, type %s\n", v1.Name(), v1.Type())
+			absPath := v1.Imported().Path()
+			n, _ := w.Loader.caravan.Find(absPath)
+			pkg1 := n.Element.(*Package)
+			fmt.Printf("From pkg %#v\n", pkg1)
+
+			oooo := pkg1.typesPkg.Scope().Lookup(v.Sel.Name)
+			if oooo != nil {
+				return oooo, pkg1, nil
+			}
+
+		case *types.Var:
+			fmt.Printf("Have Var %s, type %s\n\tv1: %#v\n\tv1.Sel: %#v\n", v1.Name(), v1.Type(), v1, v.Sel)
+			vSelObj := pkg.checker.ObjectOf(v.Sel)
+			path := vSelObj.Pkg().Path()
+			n, _ := w.Loader.caravan.Find(path)
+			pkg1 := n.Element.(*Package)
+			return vSelObj, pkg1, nil
+		}
+	case *ast.SelectorExpr:
+		vSelObj := pkg.checker.ObjectOf(v.Sel)
+		path := vSelObj.Pkg().Path()
+		n, _ := w.Loader.caravan.Find(path)
+		pkg1 := n.Element.(*Package)
+		return vSelObj, pkg1, nil
+	}
+
 	return nil, nil, nil
 }

--- a/workspace_declaration_test.go
+++ b/workspace_declaration_test.go
@@ -5,6 +5,63 @@ import (
 	"testing"
 )
 
+// func Test_Workspace_References_Local_Package(t *testing.T) {
+// 	src := `package foo
+// 	var fooInt int = 0`
+
+// 	packages := map[string]map[string]string{
+// 		"foo": map[string]string{
+// 			"foo.go": src,
+// 		},
+// 	}
+
+// 	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+// 	startPosition := &token.Position{
+// 		Filename: "/go/src/foo/foo.go",
+// 		Line:     1,
+// 		Column:   9,
+// 	}
+// 	referencePositions := []*token.Position{
+// 		startPosition,
+// 	}
+// 	testReferences(t, w, startPosition, referencePositions)
+// }
+
+func Test_Workspace_References_Imported_Package(t *testing.T) {
+	src1 := `package foo
+	const MyNumber = 0`
+
+	src2 := `package bar
+	import "../foo"
+	func Do() int {
+		return foo.MyNumber
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+		"bar": map[string]string{
+			"bar.go": src2,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/bar", packages, false)
+
+	usagePosition := &token.Position{
+		Filename: "/go/src/bar/bar.go",
+		Line:     4,
+		Column:   10,
+	}
+	declPosition := &token.Position{
+		Filename: "/go/src/bar/bar.go",
+		Line:     2,
+		Column:   9,
+	}
+	testDeclaration(t, w, usagePosition, declPosition)
+}
+
 func Test_Workspace_Declaration_Package_Const(t *testing.T) {
 	src1 := `package foo
 	const (

--- a/workspace_modify_file_test.go
+++ b/workspace_modify_file_test.go
@@ -45,7 +45,7 @@ func Test_Workspace_Modify_File(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	comparePosition(t, pos, declPosition)
+	testPosition(t, pos, declPosition)
 
 	if err := w.ChangeFile("/go/src/foo/foo.go", 2, 6, 2, 10, "foos"); err != nil {
 		t.Errorf(err.Error())
@@ -67,7 +67,7 @@ func Test_Workspace_Modify_File(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	comparePosition(t, pos, declPosition)
+	testPosition(t, pos, declPosition)
 }
 
 func Test_Workspace_Modify_Cross_File(t *testing.T) {
@@ -132,5 +132,5 @@ func Test_Workspace_Modify_Cross_File(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error while finding declaration: %s", err.Error())
 	}
-	comparePosition(t, decl, declPosition)
+	testPosition(t, decl, declPosition)
 }

--- a/workspace_references_test.go
+++ b/workspace_references_test.go
@@ -7,15 +7,105 @@ import (
 )
 
 func Test_Workspace_References_Local_Const(t *testing.T) {
-	t.SkipNow()
+	src1 := `package foo
+	const fooVal = 0
+	func IncFoo() int {
+		return fooVal
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     4,
+		Column:   10,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     2,
+			Column:   8,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
 }
 
 func Test_Workspace_References_Package_Const(t *testing.T) {
-	t.SkipNow()
+	src1 := `package foo
+	const fooVal = 0`
+
+	src2 := `package foo
+	func IncFoo() int {
+		return fooVal
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo1.go": src1,
+			"foo2.go": src2,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo2.go",
+		Line:     3,
+		Column:   10,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo1.go",
+			Line:     2,
+			Column:   8,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
 }
 
 func Test_Workspace_References_Imported_Const(t *testing.T) {
-	t.SkipNow()
+	src1 := `package foo
+	const FooVal = 0`
+
+	src2 := `package bar
+	import "../foo"
+	func IncFoo() int {
+		return foo.FooVal
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+		"bar": map[string]string{
+			"bar.go": src2,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/bar", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/bar/bar.go",
+		Line:     4,
+		Column:   14,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     2,
+			Column:   8,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
 }
 
 func Test_Workspace_References_Local_Var(t *testing.T) {
@@ -244,15 +334,112 @@ func Test_Workspace_References_Imported_Struct(t *testing.T) {
 }
 
 func Test_Workspace_References_Local_Interface(t *testing.T) {
-	t.SkipNow()
+	src1 := `package foo
+	type fooIface interface {
+		myNumber() int
+	}
+	func Do() int {
+		var f fooIface
+		return f.myNumber()
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     6,
+		Column:   9,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     2,
+			Column:   7,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
 }
 
 func Test_Workspace_References_Package_Interface(t *testing.T) {
-	t.SkipNow()
+	src1 := `package foo
+	type fooIface interface {
+		myNumber() int
+	}`
+	src2 := `package foo
+	func Do() int {
+		var f fooIface
+		return f.myNumber()
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo1.go": src1,
+			"foo2.go": src2,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo2.go",
+		Line:     3,
+		Column:   9,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo1.go",
+			Line:     2,
+			Column:   7,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
 }
 
 func Test_Workspace_References_Imported_Interface(t *testing.T) {
-	t.SkipNow()
+	src1 := `package foo
+	type FooIface interface {
+		MyNumber() int
+	}`
+	src2 := `package bar
+	import "../foo"
+	func Do() int {
+		var f foo.FooIface
+		return f.MyNumber()
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+		"bar": map[string]string{
+			"bar.go": src2,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/bar", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/bar/bar.go",
+		Line:     4,
+		Column:   13,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     2,
+			Column:   7,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
 }
 
 func Test_Workspace_References_Local_Func(t *testing.T) {
@@ -398,15 +585,130 @@ func Test_Workspace_References_Local_Selector_Field(t *testing.T) {
 }
 
 func Test_Workspace_References_Package_Selector_Field(t *testing.T) {
-	t.SkipNow()
+	src1 := `package foo
+	type fooStruct struct {
+		a int
+	}`
+	src2 := `package foo
+	func Do() int {
+		f := &fooStruct{}
+		return f.a
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo1.go": src1,
+			"foo2.go": src2,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo2.go",
+		Line:     4,
+		Column:   12,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo1.go",
+			Line:     3,
+			Column:   3,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
 }
 
 func Test_Workspace_References_Imported_Selector_Field(t *testing.T) {
-	t.SkipNow()
+	src1 := `package foo
+	type FooStruct struct {
+		A int
+	}`
+	src2 := `package bar
+	import "../foo"
+	func Do() int {
+		f := &foo.FooStruct{}
+		return f.A
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+		"bar": map[string]string{
+			"bar.go": src2,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/bar", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/bar/bar.go",
+		Line:     5,
+		Column:   12,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     3,
+			Column:   3,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
 }
 
 func Test_Workspace_References_Indirect_Imported_Selector_Field(t *testing.T) {
-	t.SkipNow()
+	src1 := `package foo
+	type FooStruct struct {
+		A int
+	}`
+	src2 := `package bar
+	import "../foo"
+	type BarStruct struct {
+		F *foo.FooStruct
+	}
+	func NewBarStruct() *BarStruct {
+		return &BarStruct {
+			F: &foo.FooStruct{}
+		}
+	}`
+	src3 := `package baz
+	import "../bar"
+	func Do() int {
+		b := bar.NewBarStruct()
+		return b.F.A
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+		"bar": map[string]string{
+			"bar.go": src2,
+		},
+		"baz": map[string]string{
+			"baz.go": src3,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/baz", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/baz/baz.go",
+		Line:     5,
+		Column:   14,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     3,
+			Column:   3,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
 }
 
 func Test_Workspace_References_Local_Selector_Method(t *testing.T) {

--- a/workspace_references_test.go
+++ b/workspace_references_test.go
@@ -1,0 +1,118 @@
+package langd
+
+import (
+	"go/token"
+	"strings"
+	"testing"
+)
+
+func Test_Workspace_References_Local_Definition(t *testing.T) {
+	src1 := `package foo
+	var fooVal int = 0
+	func IncFoo() int {
+		fooVal++
+		return fooVal
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     4,
+		Column:   3,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     2,
+			Column:   6,
+		},
+		startPosition,
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     5,
+			Column:   10,
+		},
+	}
+	testReferences(t, w, startPosition, referencePositions)
+}
+
+func Test_Workspace_References_Package_Definition(t *testing.T) {
+	src1 := `package foo
+	var fooVal int = 0`
+
+	src2 := `package foo
+	func IncFoo() int {
+		fooVal++
+		return fooVal
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo1.go": src1,
+			"foo2.go": src2,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo2.go",
+		Line:     3,
+		Column:   3,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo1.go",
+			Line:     2,
+			Column:   6,
+		},
+		startPosition,
+		&token.Position{
+			Filename: "/go/src/foo/foo2.go",
+			Line:     4,
+			Column:   10,
+		},
+	}
+	testReferences(t, w, startPosition, referencePositions)
+}
+
+func testReferences(t *testing.T, w *Workspace, startPosition *token.Position, referencePositions []*token.Position) {
+	actual := w.LocateReferences(startPosition)
+	if nil == actual {
+		t.Fatal("Got nil back")
+	}
+	if len(actual) != len(referencePositions) {
+		t.Fatalf("Incorrect number of references: got %d, expected %d", len(actual), len(referencePositions))
+	}
+	for _, v := range referencePositions {
+		found := false
+
+		for _, v1 := range actual {
+			if comparePosition(&v1, v) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			exs := make([]string, len(referencePositions))
+			for k, v := range referencePositions {
+				exs[k] = v.String()
+			}
+			exss := strings.Join(exs, "\n\t")
+			acs := make([]string, len(actual))
+			for k, v := range actual {
+				acs[k] = v.String()
+			}
+			acss := strings.Join(acs, "\n\t")
+			t.Fatalf("Did not find %s among expected positions\nactuals:\n\t%s\nexpected:\n\t%s", v.String(), acss, exss)
+		}
+	}
+}

--- a/workspace_references_test.go
+++ b/workspace_references_test.go
@@ -339,6 +339,41 @@ func Test_Workspace_References_Imported_Package_Func(t *testing.T) {
 	testReferences(t, w, startPosition, referencePositions)
 }
 
+func Test_Workspace_References_Local_Selector(t *testing.T) {
+	src := `package foo
+	type fooStruct struct {}
+	func (f *fooStruct) getFoo() int {
+		return 0
+	}
+	func Do() int {
+		f := &fooStruct{}
+		return f.getFoo()
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     8,
+		Column:   12,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     3,
+			Column:   22,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
+}
+
 func testReferences(t *testing.T, w *Workspace, startPosition *token.Position, referencePositions []*token.Position) {
 	actual := w.LocateReferences(startPosition)
 	if nil == actual {

--- a/workspace_references_test.go
+++ b/workspace_references_test.go
@@ -120,6 +120,186 @@ func Test_Workspace_References_Imported_Var(t *testing.T) {
 	testReferences(t, w, startPosition, referencePositions)
 }
 
+func Test_Workspace_References_Local_Struct(t *testing.T) {
+	src1 := `package foo
+	type fooStruct struct {
+		a string
+	}
+	func Do() {
+		f := fooStruct{}
+		f.a = "astring"
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     6,
+		Column:   8,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     2,
+			Column:   7,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
+}
+
+func Test_Workspace_References_Package_Struct(t *testing.T) {
+	src1 := `package foo
+	type fooStruct struct {
+		a string
+	}`
+
+	src2 := `package foo
+	func Do() {
+		f := fooStruct{}
+		f.a = "astring"
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo1.go": src1,
+			"foo2.go": src2,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo2.go",
+		Line:     3,
+		Column:   8,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo1.go",
+			Line:     2,
+			Column:   7,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
+}
+
+func Test_Workspace_References_Imported_Struct(t *testing.T) {
+	src1 := `package foo
+	type FooStruct struct {
+		A string
+	}`
+
+	src2 := `package bar
+	import "../foo"
+	func Do() {
+		f := foo.FooStruct{}
+		f.A = "astring"
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+		"bar": map[string]string{
+			"bar.go": src2,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/bar", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/bar/bar.go",
+		Line:     4,
+		Column:   12,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     2,
+			Column:   7,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
+}
+
+func Test_Workspace_References_Local_Func(t *testing.T) {
+	src := `package foo
+	func getFoo() int {
+		return 0
+	}
+	func Do() int {
+		return getFoo()
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     6,
+		Column:   10,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     2,
+			Column:   7,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
+}
+
+func Test_Workspace_References_Package_Func(t *testing.T) {
+	src1 := `package foo
+	func getFoo() int {
+		return 0
+	}`
+
+	src2 := `package foo
+	func Do() int {
+		return getFoo()
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo1.go": src1,
+			"foo2.go": src2,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo2.go",
+		Line:     3,
+		Column:   10,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo1.go",
+			Line:     2,
+			Column:   7,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
+}
+
 func Test_Workspace_References_Imported_Package_Func(t *testing.T) {
 	src1 := `package foo
 	func GetFoo() int {

--- a/workspace_references_test.go
+++ b/workspace_references_test.go
@@ -6,6 +6,18 @@ import (
 	"testing"
 )
 
+func Test_Workspace_References_Local_Const(t *testing.T) {
+	t.SkipNow()
+}
+
+func Test_Workspace_References_Package_Const(t *testing.T) {
+	t.SkipNow()
+}
+
+func Test_Workspace_References_Imported_Const(t *testing.T) {
+	t.SkipNow()
+}
+
 func Test_Workspace_References_Local_Var(t *testing.T) {
 	src1 := `package foo
 	var fooVal int = 0
@@ -231,6 +243,18 @@ func Test_Workspace_References_Imported_Struct(t *testing.T) {
 	testReferences(t, w, startPosition, referencePositions)
 }
 
+func Test_Workspace_References_Local_Interface(t *testing.T) {
+	t.SkipNow()
+}
+
+func Test_Workspace_References_Package_Interface(t *testing.T) {
+	t.SkipNow()
+}
+
+func Test_Workspace_References_Imported_Interface(t *testing.T) {
+	t.SkipNow()
+}
+
 func Test_Workspace_References_Local_Func(t *testing.T) {
 	src := `package foo
 	func getFoo() int {
@@ -339,7 +363,53 @@ func Test_Workspace_References_Imported_Func(t *testing.T) {
 	testReferences(t, w, startPosition, referencePositions)
 }
 
-func Test_Workspace_References_Local_Selector(t *testing.T) {
+func Test_Workspace_References_Local_Selector_Field(t *testing.T) {
+	src := `package foo
+	type fooStruct struct {
+		a int
+	}
+	func Do() int {
+		f := &fooStruct{}
+		return f.a
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	startPosition := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     7,
+		Column:   12,
+	}
+	referencePositions := []*token.Position{
+		&token.Position{
+			Filename: "/go/src/foo/foo.go",
+			Line:     3,
+			Column:   3,
+		},
+		startPosition,
+	}
+	testReferences(t, w, startPosition, referencePositions)
+}
+
+func Test_Workspace_References_Package_Selector_Field(t *testing.T) {
+	t.SkipNow()
+}
+
+func Test_Workspace_References_Imported_Selector_Field(t *testing.T) {
+	t.SkipNow()
+}
+
+func Test_Workspace_References_Indirect_Imported_Selector_Field(t *testing.T) {
+	t.SkipNow()
+}
+
+func Test_Workspace_References_Local_Selector_Method(t *testing.T) {
 	src := `package foo
 	type fooStruct struct {}
 	func (f *fooStruct) getFoo() int {
@@ -374,7 +444,7 @@ func Test_Workspace_References_Local_Selector(t *testing.T) {
 	testReferences(t, w, startPosition, referencePositions)
 }
 
-func Test_Workspace_References_Package_Selector(t *testing.T) {
+func Test_Workspace_References_Package_Selector_Method(t *testing.T) {
 	src1 := `package foo
 	type fooStruct struct {}
 	func (f *fooStruct) getFoo() int {
@@ -411,7 +481,7 @@ func Test_Workspace_References_Package_Selector(t *testing.T) {
 	testReferences(t, w, startPosition, referencePositions)
 }
 
-func Test_Workspace_References_Imported_Selector(t *testing.T) {
+func Test_Workspace_References_Imported_Selector_Method(t *testing.T) {
 	src1 := `package foo
 	type FooStruct struct {}
 	func (f *FooStruct) GetFoo() int {
@@ -451,7 +521,7 @@ func Test_Workspace_References_Imported_Selector(t *testing.T) {
 	testReferences(t, w, startPosition, referencePositions)
 }
 
-func Test_Workspace_References_Indirect_Selector(t *testing.T) {
+func Test_Workspace_References_Indirect_Imported_Selector_Method(t *testing.T) {
 	src1 := `package foo
 	type FooStruct struct {}
 	func (f *FooStruct) GetFoo() int {

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -23,7 +23,10 @@ func workspaceSetup(t *testing.T, startingPath string, packages map[string]map[s
 	w.log.SetLevel(log.Verbose)
 
 	done := loader.Start()
-	loader.LoadDirectory(startingPath)
+	err := loader.LoadDirectory(startingPath)
+	if err != nil {
+		t.Fatalf("Error while loading directory '%s': %s", startingPath, err.Error())
+	}
 	<-done
 
 	if expectFailure {

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -60,10 +60,10 @@ func testDeclaration(t *testing.T, w *Workspace, usagePosition, expectedDeclPosi
 		t.Fatal(err.Error())
 	}
 
-	comparePosition(t, declPosition, expectedDeclPosition)
+	testPosition(t, declPosition, expectedDeclPosition)
 }
 
-func comparePosition(t *testing.T, actual, expected *token.Position) {
+func testPosition(t *testing.T, actual, expected *token.Position) {
 	if actual == nil {
 		t.Fatalf("actual is nil")
 	}
@@ -83,4 +83,28 @@ func comparePosition(t *testing.T, actual, expected *token.Position) {
 	if actual.Column != expected.Column {
 		t.Fatalf("Incorrect column: got %d, expected %d", actual.Column, expected.Column)
 	}
+}
+
+func comparePosition(actual, expected *token.Position) bool {
+	if actual == nil {
+		return false
+	}
+
+	if !actual.IsValid() {
+		return false
+	}
+
+	if actual.Filename != expected.Filename {
+		return false
+	}
+
+	if actual.Line != expected.Line {
+		return false
+	}
+
+	if actual.Column != expected.Column {
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
Want to be able to see where an object is used throughout the code base.  This can be within a given file, within a package, consuming an exported object through a directly imported package, or through a package that's indirectly imported via another intermediate package.