### PR TITLE
Fixing OpenFile to rebuild AST for ascendants

### DIFF
--- a/references.go
+++ b/references.go
@@ -17,16 +17,19 @@ type ref struct {
 func (w *Workspace) locateReferences(obj types.Object, pkg *Package) []*ref {
 	// obj := pkg.checker.ObjectOf(ident)
 	if obj == nil {
+		fmt.Printf("No obj provided\n")
 		// Special case
 	}
 
 	// If this is a package name, do something special also.
 	if _, ok := obj.(*types.PkgName); ok {
 		// *shrug*
+		fmt.Printf("Package name\n")
 	}
 
 	if obj.Pkg() == nil {
 		// Uhhh, not sure what this is?  A keyword or something?
+		fmt.Printf("obj.Pkg is nil\n")
 	}
 
 	// Start off with in-package references, shall we?
@@ -39,8 +42,10 @@ func (w *Workspace) locateReferences(obj types.Object, pkg *Package) []*ref {
 			})
 		}
 	}
+	fmt.Printf("Starting with %d local refs\n", len(refs))
 
 	if obj.Exported() {
+		fmt.Printf("Exported obj\n")
 		n, ok := w.Loader.caravan.Find(pkg.absPath)
 		if !ok {
 			// Should never get here.
@@ -48,17 +53,45 @@ func (w *Workspace) locateReferences(obj types.Object, pkg *Package) []*ref {
 		}
 		fmt.Printf("obj: %#v\n", obj)
 		asc := flattenAscendants(n)
-		refs = checkAscendants(asc, obj)
+		fmt.Printf("Have %d ascendants\n", len(asc))
+		ascRefs := w.checkAscendants(asc, obj)
+		for _, r := range ascRefs {
+			refs = append(refs, r)
+		}
 	}
 
+	fmt.Printf("Returning %d refs\n", len(refs))
 	return refs
 }
 
-func checkAscendants(ascendants map[string]*Package, obj types.Object) []*ref {
+func (w *Workspace) checkAscendants(ascendants map[string]*Package, obj types.Object) []*ref {
 	refs := []*ref{}
+
+	objNode, _ := w.Loader.caravan.Find(obj.Pkg().Path())
+	objPkg := objNode.Element.(*Package)
+	objPos := objPkg.Fset.Position(obj.Pos())
+	fmt.Printf("Looking for '%s':\n\t%#v\n\tin '%s'\n", obj.Name(), obj, objPos.String())
+
 	for _, pkg := range ascendants {
+		// fmt.Printf("Checking %s...\n", pkg.absPath)
+		if pkg.absPath == "/Users/bropa18/work/src/github.com/gohugoio/hugo/helpers" {
+			// fmt.Printf("Imports:\n")
+			// for path := range pkg.importPaths {
+			// 	fmt.Printf("\t%s\n", path)
+			// }
+			fmt.Printf("Uses (%d):\n", len(pkg.checker.Uses))
+			for k, v := range pkg.checker.Uses {
+				if k.Name == "NewWriter" {
+					useNode, _ := w.Loader.caravan.Find(v.Pkg().Path())
+					usePkg := useNode.Element.(*Package)
+					usePos := usePkg.Fset.Position(v.Pos())
+					fmt.Printf("\t%#v ->\n\t\t%#v\n\t\tin '%s'\n", k, v, usePos.String())
+				}
+			}
+		}
 		for id, use := range pkg.checker.Uses {
 			if sameObj(obj, use) {
+				fmt.Printf("\tmatch!  %s\n", id.String())
 				refs = append(refs, &ref{
 					pkg: pkg,
 					pos: id.Pos(),

--- a/requests/didOpen.go
+++ b/requests/didOpen.go
@@ -34,8 +34,6 @@ func (rh *didOpenHandler) preprocess(params *json.RawMessage) error {
 		return fmt.Errorf("Failed to unmarshal params")
 	}
 
-	fmt.Printf("Got parameters: %#v\n", typedParams)
-
 	uri := string(typedParams.TextDocument.URI)
 	fpath := strings.TrimPrefix(uri, "file://")
 

--- a/workspace.go
+++ b/workspace.go
@@ -217,15 +217,15 @@ func (w *Workspace) OpenFile(absFilepath, text string) error {
 }
 
 // ReplaceFile replaces the entire contents of an opened file
-func (w *Workspace) ReplaceFile(absPath, text string) error {
-	_, ok := w.Loader.openedFiles[absPath]
+func (w *Workspace) ReplaceFile(absFilepath, text string) error {
+	_, ok := w.Loader.openedFiles[absFilepath]
 	if !ok {
-		return fmt.Errorf("File %s is not opened", absPath)
+		return fmt.Errorf("File %s is not opened", absFilepath)
 	}
 
 	// Replace the entire document
 	buf := rope.CreateRope(text)
-	w.Loader.openedFiles[absPath] = buf
+	w.Loader.openedFiles[absFilepath] = buf
 
 	absPath := filepath.Dir(absFilepath)
 	n, ok := w.Loader.caravan.Find(absPath)

--- a/workspace.go
+++ b/workspace.go
@@ -203,6 +203,14 @@ func (w *Workspace) OpenFile(absFilepath, text string) error {
 	w.Loader.done = false
 	w.Loader.stateChange <- absPath
 
+	asc := flattenAscendants(n)
+
+	for _, p1 := range asc {
+		p1.loadState = unloaded
+		p1.ResetChecker()
+		w.Loader.stateChange <- p1.absPath
+	}
+
 	w.log.Debugf("Shadowed file '%s'\n", absFilepath)
 
 	return nil

--- a/workspace_hugo_test.go
+++ b/workspace_hugo_test.go
@@ -23,12 +23,8 @@ func Test_Workspace_Hugo(t *testing.T) {
 	if done == nil {
 		t.Fatal("Did not check channel back.\n")
 	}
-	fmt.Printf("Have done channel.\n")
 
 	path := "/Users/bropa18/work/src/github.com/gohugoio/hugo"
-
-	fmt.Printf("Going to load %s\n", path)
-
 	err := l.LoadDirectory(path)
 	if err != nil {
 		t.Fatalf("Failed to load directory '%s':\n\t%s\n", path, err.Error())
@@ -58,24 +54,32 @@ func Test_Workspace_Hugo(t *testing.T) {
 		t.Fatal(buf.String())
 	}
 
-	p := &token.Position{
-		Filename: "/Users/bropa18/work/src/github.com/gohugoio/hugo/helpers/processing_stats.go",
-		Line:     109,
-		Column:   24,
-	}
-	declPosition, err := w.LocateDeclaration(p)
-	if err != nil {
-		t.Error(err.Error())
-	}
-	if !declPosition.IsValid() {
-		t.Error("Returned declaration position is not valid.")
-	}
-	if declPosition.Filename != "/Users/bropa18/work/src/github.com/gohugoio/hugo/vendor/github.com/olekukonko/tablewriter/table.go" {
-		t.Errorf("Wrong file:\n\t%s\n", declPosition.Filename)
-	}
-	if declPosition.Line != 85 {
-		t.Errorf("Wrong line:\n\t%d\n", declPosition.Line)
+	declPosition := &token.Position{
+		Filename: "/Users/bropa18/work/src/github.com/gohugoio/hugo/vendor/github.com/olekukonko/tablewriter/table.go",
+		Line:     85,
+		Column:   6,
 	}
 
-	// t.Errorf("Dump logging...\n\t%s\n", declPosition.String())
+	p := &token.Position{
+		Filename: "/Users/bropa18/work/src/github.com/gohugoio/hugo/vendor/github.com/olekukonko/tablewriter/csv.go",
+		Line:     33,
+		Column:   7,
+	}
+
+	testDeclaration(t, w, p, declPosition)
+
+	testReferences(t, w, p, []*token.Position{
+		declPosition,
+		p,
+		{
+			Filename: "/Users/bropa18/work/src/github.com/gohugoio/hugo/helpers/processing_stats.go",
+			Line:     74,
+			Column:   23,
+		},
+		{
+			Filename: "/Users/bropa18/work/src/github.com/gohugoio/hugo/helpers/processing_stats.go",
+			Line:     109,
+			Column:   23,
+		},
+	})
 }


### PR DESCRIPTION
Opening a file in the editor rebuilds the AST for that package, but no ascendant packages, which causes mismatches in the object mappings.