### PR TITLE
Implement Hover functionality

### DIFF
--- a/requests/hover.go
+++ b/requests/hover.go
@@ -13,7 +13,7 @@ const (
 	hoverMethod = "textDocument/hover"
 )
 
-// hoverHandler implements the `Hoever` request
+// hoverHandler implements the `Hover` request
 // https://microsoft.github.io/language-server-protocol/specification#textDocument_hover
 type hoverHandler struct {
 	requestBase
@@ -53,6 +53,19 @@ func (rh *hoverHandler) preprocess(params *json.RawMessage) error {
 }
 
 func (rh *hoverHandler) work() error {
+	t, err := rh.h.workspace.Hover(rh.p)
+	if err != nil {
+		return err
+	}
+
+	// TODO: assign Range for interesting highlighting, etc.
+	rh.result = &Hover{
+		Contents: MarkupContent{
+			Kind:  Markdown,
+			Value: t,
+		},
+		Range: nil,
+	}
 	return nil
 }
 

--- a/requests/hover.go
+++ b/requests/hover.go
@@ -1,0 +1,61 @@
+package requests
+
+import (
+	"context"
+	"encoding/json"
+	"go/token"
+	"strings"
+
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+const (
+	hoverMethod = "textDocument/hover"
+)
+
+// hoverHandler implements the `Hoever` request
+// https://microsoft.github.io/language-server-protocol/specification#textDocument_hover
+type hoverHandler struct {
+	requestBase
+
+	p      *token.Position
+	result *Hover
+}
+
+func createHoverHandler(ctx context.Context, h *Handler, req *jsonrpc2.Request) requestHandler {
+	rh := &hoverHandler{
+		requestBase: createRequestBase(ctx, h, req, false),
+	}
+
+	return rh
+}
+
+func (rh *hoverHandler) preprocess(params *json.RawMessage) error {
+	rh.h.log.Verbosef("Got hover\n")
+
+	var typedParams TextDocumentPositionParams
+	if err := json.Unmarshal(*params, &typedParams); err != nil {
+		return err
+	}
+
+	rh.h.log.Verbosef("Got parameters: %#v\n", typedParams)
+
+	path := strings.TrimPrefix(string(typedParams.TextDocument.URI), "file://")
+
+	p := &token.Position{
+		Filename: path,
+		Line:     typedParams.Position.Line + 1,
+		Column:   typedParams.Position.Character,
+	}
+
+	rh.p = p
+	return nil
+}
+
+func (rh *hoverHandler) work() error {
+	return nil
+}
+
+func (rh *hoverHandler) reply() (interface{}, error) {
+	return rh.result, nil
+}

--- a/requests/initFuncMap.go
+++ b/requests/initFuncMap.go
@@ -30,6 +30,7 @@ func getIniterFuncs() initerFuncMap {
 			didSaveNotification:               createDidSaveHandler,
 			exitNotification:                  createExitHandler,
 			healthMethod:                      createHealthHandler,
+			hoverMethod:                       createHoverHandler,
 			initializedNotification:           createNoopNotificationHandler,
 			referencesMethod:                  createReferencesHandler,
 			shutdownMethod:                    createShutdownHandler,

--- a/requests/initialize.go
+++ b/requests/initialize.go
@@ -40,7 +40,7 @@ func (h *Handler) processInit(p *json.RawMessage) (interface{}, error) {
 				},
 				WillSave: true,
 			},
-			HoverProvider:                    false,
+			HoverProvider:                    true,
 			CompletionProvider:               nil,
 			SignatureHelpProvider:            nil,
 			DefinitionProvider:               true,

--- a/requests/types.go
+++ b/requests/types.go
@@ -106,6 +106,16 @@ type DynamicRegistration struct {
 	DynamicRegistration *bool `json:"dynamicRegistration,omitempty"`
 }
 
+// Hover is the result of a hover request.
+type Hover struct {
+	// Contents is the hover's content
+	Contents MarkupContent `json:"content"`
+
+	// Range is an optional range inside a text document, used to visualize a
+	// hover, e.g. by changing the background color.
+	Range *Range `json:"range,omitempty"`
+}
+
 type InitializeParams struct {
 	ProcessID int `json:"processId,omitempty"`
 
@@ -156,6 +166,54 @@ type InitializeParams struct {
 type InitializeResult struct {
 	// Capabilities describe what the server is capable of handling
 	Capabilities ServerCapabilities `json:"capabilities,omitempty"`
+}
+
+// MarkupKind describes the content type that a client supports in various
+// result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
+//
+// Please note that `MarkupKinds` must not start with a `$`. This kinds
+// are reserved for internal usage.
+type MarkupKind string
+
+const (
+	// PlainText is supported as a content format
+	PlainText MarkupKind = "plaintext"
+
+	// Markdown is supported as a content format
+	Markdown = "markdown"
+)
+
+// MarkupContent represents a string value which content is interpreted base on
+// its kind flag. Currently the protocol supports `plaintext` and `markdown` as
+// markup kinds.
+//
+// If the kind is `markdown` then the value can contain fenced code blocks like
+// in GitHub issues.
+// See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
+//
+// Here is an example how such a string can be constructed using JavaScript /
+// TypeScript:
+// ```ts
+// let markdown: MarkdownContent = {
+//   kind: MarkupKind.Markdown,
+//	 value: [
+//		 '# Header',
+//		 'Some text',
+//		 '```typescript',
+//		 'someCode();',
+//		 '```'
+//	 ].join('\n')
+// };
+// ```
+//
+// *Please Note* that clients might sanitize the return markdown. A client
+// could decide to remove HTML from the markdown to avoid script execution.
+type MarkupContent struct {
+	// Kind is the type of the Markup
+	Kind MarkupKind `json:"kind"`
+
+	// Value is the content itself
+	Value string `json:"value"`
 }
 
 // ReferenceContext is included in ReferenceParams for the `Find References`

--- a/workspace.go
+++ b/workspace.go
@@ -194,8 +194,6 @@ func (w *Workspace) makeTupleList(sb *strings.Builder, params *types.Tuple, vari
 			sb.WriteString(name)
 		}
 
-		fmt.Printf("%d -> %#v\n\ttype: %#v\n", k, p, p.Type())
-
 		if k < m && types.Identical(p.Type(), params.At(k+1).Type()) {
 			continue
 		}
@@ -239,7 +237,6 @@ func (w *Workspace) makeTupleList(sb *strings.Builder, params *types.Tuple, vari
 }
 
 func (w *Workspace) getVarType(sb *strings.Builder, v *types.Var) {
-	fmt.Printf("getVarType: %#v\n", v)
 	var f func(typ types.Type)
 	f = func(typ types.Type) {
 		switch t := typ.(type) {

--- a/workspace.go
+++ b/workspace.go
@@ -141,8 +141,11 @@ func (w *Workspace) makeReceiver(sb *strings.Builder, obj types.Object, pkg *Pac
 		sb.WriteRune('.')
 	} else {
 		sb.WriteRune('(')
-		sb.WriteString(rec.Name())
-		sb.WriteRune(' ')
+		name := rec.Name()
+		if len(name) != 0 {
+			sb.WriteString(name)
+			sb.WriteRune(' ')
+		}
 		w.getVarType(sb, rec)
 		sb.WriteString(") ")
 	}

--- a/workspace_hover_test.go
+++ b/workspace_hover_test.go
@@ -1,6 +1,7 @@
 package langd
 
 import (
+	"fmt"
 	"go/token"
 	"testing"
 )
@@ -33,6 +34,166 @@ func Test_Workspace_Hover_Local_Const(t *testing.T) {
 	if text != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, text)
 	}
+}
+
+func Test_Workspace_Hover_Package_Func(t *testing.T) {
+	src1 := `package foo
+	func DoFoo%s`
+
+	src2 := `package bar
+	import "../foo"
+	func Do() {
+		foo.DoFoo(%s)
+	}`
+
+	tests := []struct {
+		name      string
+		declFunc  string
+		usageArgs string
+		expected  string
+	}{
+		{
+			name:      "empty",
+			declFunc:  "() {}",
+			usageArgs: "",
+			expected:  "foo.DoFoo func()",
+		},
+		{
+			name:      "with basic args",
+			declFunc:  "(a int, b string) {}",
+			usageArgs: "1, \"foo\"",
+			expected:  "foo.DoFoo func(a int, b string)",
+		},
+		{
+			name:      "with anonymized arg",
+			declFunc:  "(a int, _ string) {}",
+			usageArgs: "1, \"foo\"",
+			expected:  "foo.DoFoo func(a int, _ string)",
+		},
+		{
+			name:      "with repeated type args",
+			declFunc:  "(a, b int) {}",
+			usageArgs: "1, 2",
+			expected:  "foo.DoFoo func(a, b int)",
+		},
+		{
+			name:      "with struct arg",
+			declFunc:  "(a int, b Foo) {}\n\ttype Foo struct {}",
+			usageArgs: "1, foo.Foo{}",
+			expected:  "foo.DoFoo func(a int, b foo.Foo)",
+		},
+		{
+			name:      "with struct pointer arg",
+			declFunc:  "(a int, b *Foo) {}\n\ttype Foo struct {}",
+			usageArgs: "1, nil",
+			expected:  "foo.DoFoo func(a int, b *foo.Foo)",
+		},
+		{
+			name:      "with repeated type pointer args",
+			declFunc:  "(a, b *Foo) {}\n\ttype Foo struct {}",
+			usageArgs: "nil, nil",
+			expected:  "foo.DoFoo func(a, b *foo.Foo)",
+		},
+		{
+			name:      "with different struct pointer args",
+			declFunc:  "(a *Foo1, b *Foo2) {}\n\ttype Foo1 struct {}\n\ttype Foo2 struct {}",
+			usageArgs: "nil, nil",
+			expected:  "foo.DoFoo func(a *foo.Foo1, b *foo.Foo2)",
+		},
+		{
+			name:      "with a pointer pointer arg",
+			declFunc:  "(a **int) {}",
+			usageArgs: "nil",
+			expected:  "foo.DoFoo func(a **int)",
+		},
+		{
+			name:      "with a blank function arg",
+			declFunc:  "(a int, f func()) {}",
+			usageArgs: "1, func() {}",
+			expected:  "foo.DoFoo func(a int, f func())",
+		},
+		{
+			name:      "with a slice parameter",
+			declFunc:  "(a int, b []string) {}",
+			usageArgs: "1, nil",
+			expected:  "foo.DoFoo func(a int, b []string)",
+		},
+		{
+			name:      "with a slice parameter",
+			declFunc:  "(a int, b []string, c []string) {}",
+			usageArgs: "1, nil, nil",
+			expected:  "foo.DoFoo func(a int, b, c []string)",
+		},
+		{
+			name:      "with a variadic parameter",
+			declFunc:  "(a int, b ...string) {}",
+			usageArgs: "1",
+			expected:  "foo.DoFoo func(a int, b ...string)",
+		},
+		{
+			name:      "with a slice and variadic parameter",
+			declFunc:  "(a int, b []string, c ...string) {}",
+			usageArgs: "1, nil",
+			expected:  "foo.DoFoo func(a int, b []string, c ...string)",
+		},
+		{
+			name:      "with slices and a variadic parameter",
+			declFunc:  "(a int, b []string, c []string, d ...string) {}",
+			usageArgs: "1, nil, nil",
+			expected:  "foo.DoFoo func(a int, b, c []string, d ...string)",
+		},
+		{
+			name:      "with a basic type return",
+			declFunc:  "() int { return 0 }",
+			usageArgs: "",
+			expected:  "foo.DoFoo func() int",
+		},
+		{
+			name:      "with a pointer struct return",
+			declFunc:  "() *Foo { return nil }\n\ttype Foo struct {}",
+			usageArgs: "",
+			expected:  "foo.DoFoo func() *foo.Foo",
+		},
+		{
+			name:      "with a basic type and an error return",
+			declFunc:  "() (int, error) { return 0, nil }",
+			usageArgs: "",
+			expected:  "foo.DoFoo func() (int, error)",
+		},
+		// More return value tests...
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			packages := map[string]map[string]string{
+				"foo": map[string]string{
+					"foo.go": fmt.Sprintf(src1, tc.declFunc),
+				},
+				"bar": map[string]string{
+					"bar.go": fmt.Sprintf(src2, tc.usageArgs),
+				},
+			}
+
+			w := workspaceSetup(t, "/go/src/bar", packages, false)
+
+			p := &token.Position{
+				Filename: "/go/src/bar/bar.go",
+				Line:     4,
+				Column:   7,
+			}
+			text, err := w.Hover(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if text != tc.expected {
+				t.Errorf("Expected '%s', got '%s'", tc.expected, text)
+			}
+		})
+	}
+}
+
+func Test_Workspace_Hover_Struct_Func(t *testing.T) {
 }
 
 func Test_Workspace_Hover_Local_Var_Basic(t *testing.T) {

--- a/workspace_hover_test.go
+++ b/workspace_hover_test.go
@@ -56,116 +56,115 @@ func Test_Workspace_Hover_Package_Func(t *testing.T) {
 			name:      "empty",
 			declFunc:  "() {}",
 			usageArgs: "",
-			expected:  "foo.DoFoo func()",
+			expected:  "func foo.DoFoo()",
 		},
 		{
 			name:      "with basic args",
 			declFunc:  "(a int, b string) {}",
 			usageArgs: "1, \"foo\"",
-			expected:  "foo.DoFoo func(a int, b string)",
+			expected:  "func foo.DoFoo(a int, b string)",
 		},
 		{
 			name:      "with anonymized arg",
 			declFunc:  "(a int, _ string) {}",
 			usageArgs: "1, \"foo\"",
-			expected:  "foo.DoFoo func(a int, _ string)",
+			expected:  "func foo.DoFoo(a int, _ string)",
 		},
 		{
 			name:      "with repeated type args",
 			declFunc:  "(a, b int) {}",
 			usageArgs: "1, 2",
-			expected:  "foo.DoFoo func(a, b int)",
+			expected:  "func foo.DoFoo(a, b int)",
 		},
 		{
 			name:      "with struct arg",
 			declFunc:  "(a int, b Foo) {}\n\ttype Foo struct {}",
 			usageArgs: "1, foo.Foo{}",
-			expected:  "foo.DoFoo func(a int, b foo.Foo)",
+			expected:  "func foo.DoFoo(a int, b foo.Foo)",
 		},
 		{
 			name:      "with struct pointer arg",
 			declFunc:  "(a int, b *Foo) {}\n\ttype Foo struct {}",
 			usageArgs: "1, nil",
-			expected:  "foo.DoFoo func(a int, b *foo.Foo)",
+			expected:  "func foo.DoFoo(a int, b *foo.Foo)",
 		},
 		{
 			name:      "with repeated type pointer args",
 			declFunc:  "(a, b *Foo) {}\n\ttype Foo struct {}",
 			usageArgs: "nil, nil",
-			expected:  "foo.DoFoo func(a, b *foo.Foo)",
+			expected:  "func foo.DoFoo(a, b *foo.Foo)",
 		},
 		{
 			name:      "with different struct pointer args",
 			declFunc:  "(a *Foo1, b *Foo2) {}\n\ttype Foo1 struct {}\n\ttype Foo2 struct {}",
 			usageArgs: "nil, nil",
-			expected:  "foo.DoFoo func(a *foo.Foo1, b *foo.Foo2)",
+			expected:  "func foo.DoFoo(a *foo.Foo1, b *foo.Foo2)",
 		},
 		{
 			name:      "with a pointer pointer arg",
 			declFunc:  "(a **int) {}",
 			usageArgs: "nil",
-			expected:  "foo.DoFoo func(a **int)",
+			expected:  "func foo.DoFoo(a **int)",
 		},
 		{
 			name:      "with a blank function arg",
 			declFunc:  "(a int, f func()) {}",
 			usageArgs: "1, func() {}",
-			expected:  "foo.DoFoo func(a int, f func())",
+			expected:  "func foo.DoFoo(a int, f func())",
 		},
 		{
 			name:      "with a slice parameter",
 			declFunc:  "(a int, b []string) {}",
 			usageArgs: "1, nil",
-			expected:  "foo.DoFoo func(a int, b []string)",
+			expected:  "func foo.DoFoo(a int, b []string)",
 		},
 		{
 			name:      "with a slice parameter",
 			declFunc:  "(a int, b []string, c []string) {}",
 			usageArgs: "1, nil, nil",
-			expected:  "foo.DoFoo func(a int, b, c []string)",
+			expected:  "func foo.DoFoo(a int, b, c []string)",
 		},
 		{
 			name:      "with a variadic parameter",
 			declFunc:  "(a int, b ...string) {}",
 			usageArgs: "1",
-			expected:  "foo.DoFoo func(a int, b ...string)",
+			expected:  "func foo.DoFoo(a int, b ...string)",
 		},
 		{
 			name:      "with a slice and variadic parameter",
 			declFunc:  "(a int, b []string, c ...string) {}",
 			usageArgs: "1, nil",
-			expected:  "foo.DoFoo func(a int, b []string, c ...string)",
+			expected:  "func foo.DoFoo(a int, b []string, c ...string)",
 		},
 		{
 			name:      "with slices and a variadic parameter",
 			declFunc:  "(a int, b []string, c []string, d ...string) {}",
 			usageArgs: "1, nil, nil",
-			expected:  "foo.DoFoo func(a int, b, c []string, d ...string)",
+			expected:  "func foo.DoFoo(a int, b, c []string, d ...string)",
 		},
 		{
 			name:      "with a basic type return",
 			declFunc:  "() int { return 0 }",
 			usageArgs: "",
-			expected:  "foo.DoFoo func() int",
+			expected:  "func foo.DoFoo() int",
 		},
 		{
 			name:      "with a pointer struct return",
 			declFunc:  "() *Foo { return nil }\n\ttype Foo struct {}",
 			usageArgs: "",
-			expected:  "foo.DoFoo func() *foo.Foo",
+			expected:  "func foo.DoFoo() *foo.Foo",
 		},
 		{
 			name:      "with a basic type and an error return",
 			declFunc:  "() (int, error) { return 0, nil }",
 			usageArgs: "",
-			expected:  "foo.DoFoo func() (int, error)",
+			expected:  "func foo.DoFoo() (int, error)",
 		},
 		// More return value tests...
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			packages := map[string]map[string]string{
 				"foo": map[string]string{
 					"foo.go": fmt.Sprintf(src1, tc.declFunc),
@@ -193,7 +192,60 @@ func Test_Workspace_Hover_Package_Func(t *testing.T) {
 	}
 }
 
-func Test_Workspace_Hover_Struct_Func(t *testing.T) {
+func Test_Workspace_Hover_Struct_Pointer_Receiver_Func(t *testing.T) {
+	src1 := `package foo
+	type Foo struct {}
+	func (%s *Foo) Do()`
+
+	src2 := `package bar
+	import "../foo"
+	func Do() {
+		f := foo.Foo{}
+		f.Do()
+	}`
+
+	tests := []struct {
+		name         string
+		receiverName string
+		expected     string
+	}{
+		{
+			name:         "with named receiver",
+			receiverName: "f",
+			expected:     "func (f *foo.Foo) Do()",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			packages := map[string]map[string]string{
+				"foo": map[string]string{
+					"foo.go": fmt.Sprintf(src1, tc.receiverName),
+				},
+				"bar": map[string]string{
+					"bar.go": src2,
+				},
+			}
+
+			w := workspaceSetup(t, "/go/src/bar", packages, false)
+
+			p := &token.Position{
+				Filename: "/go/src/bar/bar.go",
+				Line:     5,
+				Column:   5,
+			}
+			text, err := w.Hover(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if text != tc.expected {
+				t.Errorf("Expected '%s', got '%s'", tc.expected, text)
+			}
+		})
+	}
+}
+
+func Test_Workspace_Hover_Struct_Value_Receiver_Func(t *testing.T) {
 }
 
 func Test_Workspace_Hover_Local_Var_Basic(t *testing.T) {

--- a/workspace_hover_test.go
+++ b/workspace_hover_test.go
@@ -1,0 +1,79 @@
+package langd
+
+import (
+	"go/token"
+	"testing"
+)
+
+const (
+	test = 2
+)
+
+func Test_Workspace_Hover_Local_Const(t *testing.T) {
+	src1 := `package foo
+	const fooVal = 0
+	func IncFoo() int {
+		return fooVal
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	p := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     4,
+		Column:   10,
+	}
+	text, err := w.Hover(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "const foo.fooVal int = 0"
+	if text != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, text)
+	}
+}
+
+func Test_Workspace_Hover_Local_Basic_Var(t *testing.T) {
+	src1 := `package foo
+	var ival int = 10
+	func foof() int {
+		ival += 1
+		return ival
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	done := w.Loader.Start()
+
+	if err := w.OpenFile("/go/src/foo/foo.go", src1); err != nil {
+		t.Fatalf("Error while opening file: %s", err.Error())
+	}
+
+	<-done
+
+	p := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     4,
+		Column:   3,
+	}
+	text, err := w.Hover(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "foo.ival int"
+	if text != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, text)
+	}
+}

--- a/workspace_hover_test.go
+++ b/workspace_hover_test.go
@@ -5,10 +5,6 @@ import (
 	"testing"
 )
 
-const (
-	test = 2
-)
-
 func Test_Workspace_Hover_Local_Const(t *testing.T) {
 	src1 := `package foo
 	const fooVal = 0
@@ -39,7 +35,7 @@ func Test_Workspace_Hover_Local_Const(t *testing.T) {
 	}
 }
 
-func Test_Workspace_Hover_Local_Basic_Var(t *testing.T) {
+func Test_Workspace_Hover_Local_Var_Basic(t *testing.T) {
 	src1 := `package foo
 	var ival int = 10
 	func foof() int {
@@ -55,14 +51,6 @@ func Test_Workspace_Hover_Local_Basic_Var(t *testing.T) {
 
 	w := workspaceSetup(t, "/go/src/foo", packages, false)
 
-	done := w.Loader.Start()
-
-	if err := w.OpenFile("/go/src/foo/foo.go", src1); err != nil {
-		t.Fatalf("Error while opening file: %s", err.Error())
-	}
-
-	<-done
-
 	p := &token.Position{
 		Filename: "/go/src/foo/foo.go",
 		Line:     4,
@@ -73,6 +61,112 @@ func Test_Workspace_Hover_Local_Basic_Var(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := "foo.ival int"
+	if text != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, text)
+	}
+}
+
+func Test_Workspace_Hover_Local_Var_Struct_Empty(t *testing.T) {
+	src1 := `package foo
+	type fooer struct {
+	}
+	var ival fooer
+	func foof() fooer {
+		return ival
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	p := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     6,
+		Column:   10,
+	}
+	text, err := w.Hover(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "type foo.fooer struct {}"
+	if text != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, text)
+	}
+}
+
+func Test_Workspace_Hover_Local_Var_Struct_With_Fields(t *testing.T) {
+	src1 := `package foo
+	type fooer struct {
+		a int
+		b string
+	}
+	var ival fooer
+	func foof() fooer {
+		ival.a += 1
+		return ival
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	p := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     8,
+		Column:   3,
+	}
+	text, err := w.Hover(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "type foo.fooer struct {\n\ta int\n\tb string\n}"
+	if text != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, text)
+	}
+}
+
+func Test_Workspace_Hover_Local_Var_Struct_Embedded(t *testing.T) {
+	src1 := `package foo
+	type fooer struct {
+		a int
+		b string
+	}
+	type barer struct {
+		fooer
+		c float32
+	}
+	var ival barer
+	func foof() barer {
+		ival.c += 1
+		return ival
+	}`
+
+	packages := map[string]map[string]string{
+		"foo": map[string]string{
+			"foo.go": src1,
+		},
+	}
+
+	w := workspaceSetup(t, "/go/src/foo", packages, false)
+
+	p := &token.Position{
+		Filename: "/go/src/foo/foo.go",
+		Line:     12,
+		Column:   3,
+	}
+	text, err := w.Hover(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "type foo.barer struct {\n\tfoo.fooer\n\tc float32\n}"
 	if text != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, text)
 	}

--- a/workspace_hover_test.go
+++ b/workspace_hover_test.go
@@ -214,6 +214,16 @@ func Test_Workspace_Hover_Struct_Pointer_Receiver_Func(t *testing.T) {
 			receiverName: "f",
 			expected:     "func (f *foo.Foo) Do()",
 		},
+		{
+			name:         "with named receiver",
+			receiverName: "_",
+			expected:     "func (_ *foo.Foo) Do()",
+		},
+		{
+			name:         "with named receiver",
+			receiverName: "",
+			expected:     "func (*foo.Foo) Do()",
+		},
 	}
 
 	for _, tc := range tests {
@@ -266,6 +276,16 @@ func Test_Workspace_Hover_Struct_Value_Receiver_Func(t *testing.T) {
 			name:         "with named receiver",
 			receiverName: "f",
 			expected:     "func (f foo.Foo) Do()",
+		},
+		{
+			name:         "with named receiver",
+			receiverName: "_",
+			expected:     "func (_ foo.Foo) Do()",
+		},
+		{
+			name:         "with named receiver",
+			receiverName: "",
+			expected:     "func (foo.Foo) Do()",
 		},
 	}
 


### PR DESCRIPTION
Includes hover for const, package-scoped var, structs, package funcs, and funcs attached to a struct.  Others may be happenstantially implemented, but not tested, so this is not a complete feature.  It's enough to prove functionality and provide a good starting point.  Code may need to be refactored for clarity and deduplication.